### PR TITLE
OMHD-419: Change the default mime type for null values

### DIFF
--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/util/Extensions.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/util/Extensions.kt
@@ -38,7 +38,7 @@ private val NON_SUPPORTED_MIME_TYPES_FOR_DOWNLOAD = listOf(
 fun OmhStorageEntity.OmhFile.isDownloadable(): Boolean = !NON_SUPPORTED_MIME_TYPES_FOR_DOWNLOAD.contains(getFileType())
 fun OmhStorageEntity.OmhFile.getFileType() = mimeType?.let {
     FileTypeMapper.getFileTypeWithMime(it)
-} ?: FileType.GOOGLE_UNKNOWN
+} ?: FileType.OTHER
 
 fun OmhStorageEntity.OmhFile.normalizedMimeType(): String = when (getFileType()) {
     FileType.GOOGLE_DOCUMENT -> FileType.MICROSOFT_WORD.mimeType


### PR DESCRIPTION
## Summary

This PR fixes the issues with downloading the files with null mime type. Previously if null type was null, the `GOOGLE_UNKNOWN` mime type was assigned which is listed as non downloadable.

## Demo

n/a

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-419](https://callstackio.atlassian.net/browse/OMHD-419)
