### PR TITLE
OMHD-334: OneDrive file versioning

### DIFF
--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/OneDriveOmhStorageClient.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/OneDriveOmhStorageClient.kt
@@ -98,16 +98,14 @@ internal class OneDriveOmhStorageClient @VisibleForTesting internal constructor(
     }
 
     override suspend fun getFileVersions(fileId: String): List<OmhFileVersion> {
-        // To be implemented
-        return emptyList()
+        return repository.getFileVersions(fileId)
     }
 
     override suspend fun downloadFileVersion(
         fileId: String,
         versionId: String
     ): ByteArrayOutputStream {
-        // To be implemented
-        return ByteArrayOutputStream()
+        return repository.downloadFileVersion(fileId, versionId)
     }
 
     override suspend fun getFilePermissions(fileId: String): List<OmhFilePermission> {

--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/mapper/DataMappers.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/mapper/DataMappers.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Open Mobile Hub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.openmobilehub.android.storage.plugin.onedrive.data.mapper
+
+import com.microsoft.graph.models.DriveItemVersion
+import com.openmobilehub.android.storage.core.model.OmhFileVersion
+import java.util.Date
+
+fun DriveItemVersion.toOmhVersion(fileId: String): OmhFileVersion {
+    return OmhFileVersion(
+        fileId,
+        id,
+        Date.from(lastModifiedDateTime.toInstant())
+    )
+}

--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/repository/OneDriveFileRepository.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/repository/OneDriveFileRepository.kt
@@ -16,10 +16,12 @@
 
 package com.openmobilehub.android.storage.plugin.onedrive.data.repository
 
+import com.openmobilehub.android.storage.core.model.OmhFileVersion
 import com.openmobilehub.android.storage.core.model.OmhStorageEntity
 import com.openmobilehub.android.storage.core.model.OmhStorageException
 import com.openmobilehub.android.storage.core.model.OmhStorageStatusCodes
 import com.openmobilehub.android.storage.plugin.onedrive.data.mapper.DriveItemToOmhStorageEntity
+import com.openmobilehub.android.storage.plugin.onedrive.data.mapper.toOmhVersion
 import com.openmobilehub.android.storage.plugin.onedrive.data.service.OneDriveApiService
 import com.openmobilehub.android.storage.plugin.onedrive.data.util.toByteArrayOutputStream
 import java.io.ByteArrayOutputStream
@@ -43,6 +45,22 @@ class OneDriveFileRepository(
 
     fun downloadFile(fileId: String): ByteArrayOutputStream {
         val inputStream = apiService.downloadFile(fileId)
+            ?: throw OmhStorageException.DownloadException(
+                OmhStorageStatusCodes.DOWNLOAD_ERROR,
+                null
+            )
+
+        return inputStream.toByteArrayOutputStream()
+    }
+
+    fun getFileVersions(fileId: String): List<OmhFileVersion> {
+        return apiService.getFileVersions(fileId).value.map {
+            it.toOmhVersion(fileId)
+        }
+    }
+
+    fun downloadFileVersion(fileId: String, versionId: String): ByteArrayOutputStream {
+        val inputStream = apiService.downloadFileVersion(fileId, versionId)
             ?: throw OmhStorageException.DownloadException(
                 OmhStorageStatusCodes.DOWNLOAD_ERROR,
                 null

--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveApiService.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveApiService.kt
@@ -20,6 +20,7 @@ import androidx.annotation.VisibleForTesting
 import com.microsoft.graph.drives.item.items.item.createuploadsession.CreateUploadSessionPostRequestBody
 import com.microsoft.graph.models.DriveItem
 import com.microsoft.graph.models.DriveItemUploadableProperties
+import com.microsoft.graph.models.DriveItemVersionCollectionResponse
 import com.openmobilehub.android.storage.core.model.OmhStorageException
 import com.openmobilehub.android.storage.core.model.OmhStorageStatusCodes
 import com.openmobilehub.android.storage.core.utils.toInputStream
@@ -76,6 +77,22 @@ class OneDriveApiService(private val apiClient: OneDriveApiClient) {
             .byDriveId(driveId)
             .items()
             .byDriveItemId(fileId)
+            .content()
+            .get()
+    }
+
+    fun getFileVersions(fileId: String): DriveItemVersionCollectionResponse {
+        return apiClient.graphServiceClient.drives().byDriveId(driveId).items()
+            .byDriveItemId(fileId).versions().get()
+    }
+
+    fun downloadFileVersion(fileId: String, versionId: String): InputStream? {
+        return apiClient.graphServiceClient.drives()
+            .byDriveId(driveId)
+            .items()
+            .byDriveItemId(fileId)
+            .versions()
+            .byDriveItemVersionId(versionId)
             .content()
             .get()
     }

--- a/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/OneDriveOmhStorageClientTest.kt
+++ b/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/OneDriveOmhStorageClientTest.kt
@@ -20,11 +20,14 @@ package com.openmobilehub.android.storage.plugin.onedrive
 
 import android.webkit.MimeTypeMap
 import com.openmobilehub.android.auth.core.OmhAuthClient
+import com.openmobilehub.android.storage.core.model.OmhFileVersion
 import com.openmobilehub.android.storage.core.model.OmhStorageEntity
 import com.openmobilehub.android.storage.core.model.OmhStorageException
 import com.openmobilehub.android.storage.plugin.onedrive.data.repository.OneDriveFileRepository
 import com.openmobilehub.android.storage.plugin.onedrive.testdoubles.TEST_FILE_ID
 import com.openmobilehub.android.storage.plugin.onedrive.testdoubles.TEST_FILE_PARENT_ID
+import com.openmobilehub.android.storage.plugin.onedrive.testdoubles.TEST_VERSION_FILE_ID
+import com.openmobilehub.android.storage.plugin.onedrive.testdoubles.TEST_VERSION_ID
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -172,6 +175,31 @@ internal class OneDriveOmhStorageClientTest {
 
         // Act
         val result = client.downloadFile(TEST_FILE_ID, null)
+
+        // Assert
+        assertEquals(byteArrayOutputStream, result)
+    }
+
+    @Test
+    fun `given a repository, when listing file versions, then return versions from the repository`() = runTest {
+        // Arrange
+        val versions: List<OmhFileVersion> = mockk()
+        every { repository.getFileVersions(any()) } returns versions
+
+        // Act
+        val result = client.getFileVersions(TEST_VERSION_FILE_ID)
+
+        // Assert
+        assertEquals(versions, result)
+    }
+
+    @Test
+    fun `given a repository, when downloading a file version, then return ByteArrayOutputStream`() = runTest {
+        // Arrange
+        every { repository.downloadFileVersion(any(), any()) } returns byteArrayOutputStream
+
+        // Act
+        val result = client.downloadFileVersion(TEST_VERSION_FILE_ID, TEST_VERSION_ID)
 
         // Assert
         assertEquals(byteArrayOutputStream, result)

--- a/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/data/mapper/DataMappersTest.kt
+++ b/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/data/mapper/DataMappersTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Open Mobile Hub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.openmobilehub.android.storage.plugin.onedrive.data.mapper
+
+import com.microsoft.graph.models.DriveItemVersion
+import com.openmobilehub.android.storage.plugin.onedrive.testdoubles.TEST_VERSION_FILE_ID
+import com.openmobilehub.android.storage.plugin.onedrive.testdoubles.setUpMock
+import com.openmobilehub.android.storage.plugin.onedrive.testdoubles.testOmhVersion
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.impl.annotations.MockK
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class DataMappersTest {
+
+    @MockK
+    private lateinit var driveItemVersion: DriveItemVersion
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        driveItemVersion.setUpMock()
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `given a DriveItemVersion with specific properties, when mapped, then return the expected OmhFileVersion`() {
+        // Act
+        val result = driveItemVersion.toOmhVersion(TEST_VERSION_FILE_ID)
+
+        // Assert
+        Assert.assertEquals(testOmhVersion, result)
+    }
+}

--- a/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveApiServiceTest.kt
+++ b/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveApiServiceTest.kt
@@ -20,11 +20,14 @@ package com.openmobilehub.android.storage.plugin.onedrive.data.service
 
 import com.microsoft.graph.core.models.UploadResult
 import com.microsoft.graph.models.DriveItem
+import com.microsoft.graph.models.DriveItemVersionCollectionResponse
 import com.microsoft.graph.models.UploadSession
 import com.openmobilehub.android.storage.core.model.OmhStorageException
 import com.openmobilehub.android.storage.core.utils.toInputStream
 import com.openmobilehub.android.storage.plugin.onedrive.testdoubles.TEST_FILE_ID
 import com.openmobilehub.android.storage.plugin.onedrive.testdoubles.TEST_FILE_PARENT_ID
+import com.openmobilehub.android.storage.plugin.onedrive.testdoubles.TEST_VERSION_FILE_ID
+import com.openmobilehub.android.storage.plugin.onedrive.testdoubles.TEST_VERSION_ID
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -56,6 +59,9 @@ class OneDriveApiServiceTest {
 
     @MockK
     private lateinit var inputStream: InputStream
+
+    @MockK
+    private lateinit var driveItemVersionCollectionResponse: DriveItemVersionCollectionResponse
 
     private lateinit var apiService: OneDriveApiService
 
@@ -160,6 +166,42 @@ class OneDriveApiServiceTest {
 
         // Act
         val result = apiService.downloadFile(TEST_FILE_ID)
+
+        // Assert
+        Assert.assertEquals(inputStream, result)
+    }
+
+    @Test
+    fun `given apiClient returns list of versions, when getting the file versions list, then return list of drive item version collection response`() {
+        // Arrange
+        every {
+            apiClient.graphServiceClient.drives().byDriveId(any()).items()
+                .byDriveItemId(any()).versions().get()
+        } returns driveItemVersionCollectionResponse
+
+        // Act
+        val result = apiService.getFileVersions(TEST_VERSION_FILE_ID)
+
+        // Assert
+        Assert.assertEquals(driveItemVersionCollectionResponse, result)
+    }
+
+    @Test
+    fun `given apiClient successfully download the file version, when downloading the file version, then return InputStream`() {
+        // Arrange
+        every {
+            apiClient.graphServiceClient.drives()
+                .byDriveId(any())
+                .items()
+                .byDriveItemId(any())
+                .versions()
+                .byDriveItemVersionId(any())
+                .content()
+                .get()
+        } returns inputStream
+
+        // Act
+        val result = apiService.downloadFileVersion(TEST_VERSION_FILE_ID, TEST_VERSION_ID)
 
         // Assert
         Assert.assertEquals(inputStream, result)

--- a/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/testdoubles/TestDriveItemVersion.kt
+++ b/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/testdoubles/TestDriveItemVersion.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Open Mobile Hub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.openmobilehub.android.storage.plugin.onedrive.testdoubles
+
+import com.microsoft.graph.models.DriveItemVersion
+import io.mockk.every
+import java.time.ZoneOffset
+
+internal fun DriveItemVersion.setUpMock() {
+    every { id } returns TEST_VERSION_ID
+    every { lastModifiedDateTime } returns TEST_VERSION_FILE_MODIFIED_TIME.toInstant().atOffset(ZoneOffset.UTC)
+}

--- a/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/testdoubles/TestOmhVersion.kt
+++ b/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/testdoubles/TestOmhVersion.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Open Mobile Hub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.openmobilehub.android.storage.plugin.onedrive.testdoubles
+
+import com.openmobilehub.android.storage.core.model.OmhFileVersion
+import com.openmobilehub.android.storage.core.utils.fromRFC3339StringToDate
+
+const val TEST_VERSION_FILE_ID = "123"
+const val TEST_VERSION_ID = "456"
+val TEST_VERSION_FILE_MODIFIED_TIME = "2023-07-04T03:03:55.397Z".fromRFC3339StringToDate()!!
+
+val testOmhVersion = OmhFileVersion(
+    TEST_VERSION_FILE_ID,
+    TEST_VERSION_ID,
+    TEST_VERSION_FILE_MODIFIED_TIME
+)


### PR DESCRIPTION
## Summary

This PR adds file versioning support for OneDrive.

## Demo

https://github.com/openmobilehub/android-omh-storage/assets/23010554/50e1e610-d207-4507-91d1-b256a3b7897c

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-334](https://callstackio.atlassian.net/browse/OMHD-334)
