### PR TITLE
test: add unit tests to OmhCreatePermission mappers

### DIFF
--- a/packages/plugin-googledrive-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/mapper/DataMappersTest.kt
+++ b/packages/plugin-googledrive-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/mapper/DataMappersTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 Open Mobile Hub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("MaxLineLength")
+
+package com.openmobilehub.android.storage.plugin.googledrive.gms.data.mapper
+
+import com.openmobilehub.android.storage.core.model.OmhCreatePermission
+import com.openmobilehub.android.storage.core.model.OmhPermissionRole
+import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.ANYONE_TYPE
+import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.DOMAIN_TYPE
+import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.GROUP_TYPE
+import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.USER_TYPE
+import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.WRITER_ROLE
+import com.openmobilehub.android.storage.plugin.googledrive.gms.data.repository.testdoubles.TEST_PERMISSION_DOMAIN
+import com.openmobilehub.android.storage.plugin.googledrive.gms.data.repository.testdoubles.TEST_PERMISSION_EMAIL_ADDRESS
+import org.junit.Test
+import kotlin.test.assertEquals
+
+internal class DataMappersTest {
+
+    @Test
+    fun `given a AnyonePermission, when toPermission is called, then a Permission with corresponding fields is returned`() {
+        val anyonePermission = OmhCreatePermission.AnyonePermission(OmhPermissionRole.WRITER)
+
+        val result = anyonePermission.toPermission()
+
+        assertEquals(ANYONE_TYPE, result.type)
+        assertEquals(WRITER_ROLE, result.role)
+    }
+
+    @Test
+    fun `given a DomainPermission, when toPermission is called, then a Permission with corresponding fields is returned`() {
+        val domainPermission =
+            OmhCreatePermission.DomainPermission(OmhPermissionRole.WRITER, TEST_PERMISSION_DOMAIN)
+
+        val result = domainPermission.toPermission()
+
+        assertEquals(DOMAIN_TYPE, result.type)
+        assertEquals(WRITER_ROLE, result.role)
+        assertEquals(TEST_PERMISSION_DOMAIN, result.domain)
+    }
+
+    @Test
+    fun `given a GroupPermission, when toPermission is called, then a Permission with corresponding fields is returned`() {
+        val groupPermission = OmhCreatePermission.GroupPermission(
+            OmhPermissionRole.WRITER,
+            TEST_PERMISSION_EMAIL_ADDRESS
+        )
+
+        val result = groupPermission.toPermission()
+
+        assertEquals(GROUP_TYPE, result.type)
+        assertEquals(WRITER_ROLE, result.role)
+        assertEquals(TEST_PERMISSION_EMAIL_ADDRESS, result.emailAddress)
+    }
+
+    @Test
+    fun `given a UserPermission, when toPermission is called, then a Permission with corresponding fields is returned`() {
+        val groupPermission = OmhCreatePermission.UserPermission(
+            OmhPermissionRole.WRITER,
+            TEST_PERMISSION_EMAIL_ADDRESS
+        )
+
+        val result = groupPermission.toPermission()
+
+        assertEquals(USER_TYPE, result.type)
+        assertEquals(WRITER_ROLE, result.role)
+        assertEquals(TEST_PERMISSION_EMAIL_ADDRESS, result.emailAddress)
+    }
+}

--- a/packages/plugin-googledrive-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/repository/testdoubles/TestOmhPermission.kt
+++ b/packages/plugin-googledrive-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/repository/testdoubles/TestOmhPermission.kt
@@ -24,6 +24,7 @@ import com.openmobilehub.android.storage.core.utils.fromRFC3339StringToDate
 const val TEST_PERMISSION_ID = "123"
 const val TEST_PERMISSION_DISPLAY_NAME = "Tester"
 const val TEST_PERMISSION_EMAIL_ADDRESS = "test@test.com"
+const val TEST_PERMISSION_DOMAIN = "test.com"
 val TEST_PERMISSION_EXPIRATION_TIME = TEST_FIRST_MAY_2024_RFC_3339.fromRFC3339StringToDate()
 const val TEST_PERMISSION_PHOTO_LINK = "https://test.com/image"
 

--- a/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/mapper/DataMappersTest.kt
+++ b/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/mapper/DataMappersTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 Open Mobile Hub
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("MaxLineLength")
+
+package com.openmobilehub.android.storage.plugin.googledrive.nongms.data.mapper
+
+import com.openmobilehub.android.storage.core.model.OmhCreatePermission
+import com.openmobilehub.android.storage.core.model.OmhPermissionRole
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.ANYONE_TYPE
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.DOMAIN_TYPE
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.GROUP_TYPE
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.USER_TYPE
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.WRITER_ROLE
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.repository.testdoubles.TEST_PERMISSION_DOMAIN
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.repository.testdoubles.TEST_PERMISSION_EMAIL_ADDRESS
+import org.junit.Test
+import kotlin.test.assertEquals
+
+internal class DataMappersTest {
+
+    @Test
+    fun `given a AnyonePermission, when toCreateRequestBody is called, then a Permission with corresponding fields is returned`() {
+        val anyonePermission = OmhCreatePermission.AnyonePermission(OmhPermissionRole.WRITER)
+
+        val result = anyonePermission.toCreateRequestBody()
+
+        assertEquals(ANYONE_TYPE, result.type)
+        assertEquals(WRITER_ROLE, result.role)
+    }
+
+    @Test
+    fun `given a DomainPermission, when toCreateRequestBody is called, then a Permission with corresponding fields is returned`() {
+        val domainPermission =
+            OmhCreatePermission.DomainPermission(OmhPermissionRole.WRITER, TEST_PERMISSION_DOMAIN)
+
+        val result = domainPermission.toCreateRequestBody()
+
+        assertEquals(DOMAIN_TYPE, result.type)
+        assertEquals(WRITER_ROLE, result.role)
+        assertEquals(TEST_PERMISSION_DOMAIN, result.domain)
+    }
+
+    @Test
+    fun `given a GroupPermission, when toCreateRequestBody is called, then a Permission with corresponding fields is returned`() {
+        val groupPermission = OmhCreatePermission.GroupPermission(
+            OmhPermissionRole.WRITER,
+            TEST_PERMISSION_EMAIL_ADDRESS
+        )
+
+        val result = groupPermission.toCreateRequestBody()
+
+        assertEquals(GROUP_TYPE, result.type)
+        assertEquals(WRITER_ROLE, result.role)
+        assertEquals(TEST_PERMISSION_EMAIL_ADDRESS, result.emailAddress)
+    }
+
+    @Test
+    fun `given a UserPermission, when toCreateRequestBody is called, then a Permission with corresponding fields is returned`() {
+        val groupPermission = OmhCreatePermission.UserPermission(
+            OmhPermissionRole.WRITER,
+            TEST_PERMISSION_EMAIL_ADDRESS
+        )
+
+        val result = groupPermission.toCreateRequestBody()
+
+        assertEquals(USER_TYPE, result.type)
+        assertEquals(WRITER_ROLE, result.role)
+        assertEquals(TEST_PERMISSION_EMAIL_ADDRESS, result.emailAddress)
+    }
+}

--- a/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/testdoubles/TestOmhPermission.kt
+++ b/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/testdoubles/TestOmhPermission.kt
@@ -24,6 +24,7 @@ import com.openmobilehub.android.storage.core.utils.fromRFC3339StringToDate
 const val TEST_PERMISSION_ID = "123"
 const val TEST_PERMISSION_DISPLAY_NAME = "Tester"
 const val TEST_PERMISSION_EMAIL_ADDRESS = "test@test.com"
+const val TEST_PERMISSION_DOMAIN = "test.com"
 val TEST_PERMISSION_EXPIRATION_TIME = TEST_FIRST_MAY_2024_RFC_3339.fromRFC3339StringToDate()
 const val TEST_PERMISSION_PHOTO_LINK = "https://test.com/image"
 


### PR DESCRIPTION
## Summary
There is no bug as explained [here](https://callstackio.atlassian.net/browse/OMHD-440?focusedCommentId=10348), but missing unit tests are added.

## Demo
n/a

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-440](https://callstackio.atlassian.net/browse/OMHD-440)
