### PR TITLE
fix: remove permissions specific to Shared Drive and block changing owner

### DIFF
--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/FilePermissionsViewModel.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/FilePermissionsViewModel.kt
@@ -155,9 +155,7 @@ private fun OmhPermission.orderByType(): Int = when (this) {
 @Suppress("MagicNumber")
 private fun OmhPermission.orderRole(): Int = when (this.role) {
     OmhPermissionRole.OWNER -> 0
-    OmhPermissionRole.ORGANIZER -> 1
-    OmhPermissionRole.FILE_ORGANIZER -> 2
-    OmhPermissionRole.WRITER -> 3
-    OmhPermissionRole.COMMENTER -> 4
-    OmhPermissionRole.READER -> 5
+    OmhPermissionRole.WRITER -> 1
+    OmhPermissionRole.COMMENTER -> 2
+    OmhPermissionRole.READER -> 3
 }

--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/create/CreatePermissionViewModel.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/create/CreatePermissionViewModel.kt
@@ -38,6 +38,7 @@ class CreatePermissionViewModel @Inject constructor() : ViewModel() {
     val action = _action.receiveAsFlow()
 
     val roles = OmhPermissionRole.values()
+        .filter { it != OmhPermissionRole.OWNER } // Changing the owner of a file requires a separate flow
     private val _role: MutableStateFlow<OmhPermissionRole> =
         MutableStateFlow(OmhPermissionRole.READER)
     val role: StateFlow<OmhPermissionRole> = _role

--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/edit/EditPermissionViewModel.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/edit/EditPermissionViewModel.kt
@@ -24,6 +24,7 @@ import javax.inject.Inject
 @HiltViewModel
 class EditPermissionViewModel @Inject constructor() : ViewModel() {
     val roles = OmhPermissionRole.values()
+        .filter { it != OmhPermissionRole.OWNER } // Changing the owner of a file requires a separate flow
     var role: OmhPermissionRole? = null
 
     var roleIndex: Int

--- a/packages/core/src/main/java/com/openmobilehub/android/storage/core/model/OmhPermission.kt
+++ b/packages/core/src/main/java/com/openmobilehub/android/storage/core/model/OmhPermission.kt
@@ -58,8 +58,6 @@ sealed class OmhPermission(
 
 enum class OmhPermissionRole {
     OWNER,
-    ORGANIZER,
-    FILE_ORGANIZER,
     WRITER,
     COMMENTER,
     READER,

--- a/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/GoogleDriveGmsConstants.kt
+++ b/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/GoogleDriveGmsConstants.kt
@@ -30,8 +30,6 @@ object GoogleDriveGmsConstants {
     internal const val ANYONE_TYPE = "anyone"
 
     internal const val OWNER_ROLE = "owner"
-    internal const val ORGANIZER_ROLE = "organizer"
-    internal const val FILE_ORGANIZER_ROLE = "fileOrganizer"
     internal const val WRITER_ROLE = "writer"
     internal const val COMMENTER_ROLE = "commenter"
     internal const val READER_ROLE = "reader"

--- a/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/mapper/DataMappers.kt
+++ b/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/mapper/DataMappers.kt
@@ -29,9 +29,7 @@ import com.openmobilehub.android.storage.core.model.OmhStorageEntity
 import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.ANYONE_TYPE
 import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.COMMENTER_ROLE
 import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.DOMAIN_TYPE
-import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.FILE_ORGANIZER_ROLE
 import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.GROUP_TYPE
-import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.ORGANIZER_ROLE
 import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.OWNER_ROLE
 import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.READER_ROLE
 import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants.USER_TYPE
@@ -157,8 +155,6 @@ internal fun Permission.toOmhPermission(): OmhPermission? {
 
 internal fun String.stringToRole(): OmhPermissionRole? = when (this) {
     OWNER_ROLE -> OmhPermissionRole.OWNER
-    ORGANIZER_ROLE -> OmhPermissionRole.ORGANIZER
-    FILE_ORGANIZER_ROLE -> OmhPermissionRole.FILE_ORGANIZER
     WRITER_ROLE -> OmhPermissionRole.WRITER
     COMMENTER_ROLE -> OmhPermissionRole.COMMENTER
     READER_ROLE -> OmhPermissionRole.READER
@@ -167,8 +163,6 @@ internal fun String.stringToRole(): OmhPermissionRole? = when (this) {
 
 internal fun OmhPermissionRole.toStringRole(): String = when (this) {
     OmhPermissionRole.OWNER -> OWNER_ROLE
-    OmhPermissionRole.ORGANIZER -> ORGANIZER_ROLE
-    OmhPermissionRole.FILE_ORGANIZER -> FILE_ORGANIZER_ROLE
     OmhPermissionRole.WRITER -> WRITER_ROLE
     OmhPermissionRole.COMMENTER -> COMMENTER_ROLE
     OmhPermissionRole.READER -> READER_ROLE

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/GoogleDriveNonGmsConstants.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/GoogleDriveNonGmsConstants.kt
@@ -30,8 +30,6 @@ object GoogleDriveNonGmsConstants {
     internal const val ANYONE_TYPE = "anyone"
 
     internal const val OWNER_ROLE = "owner"
-    internal const val ORGANIZER_ROLE = "organizer"
-    internal const val FILE_ORGANIZER_ROLE = "fileOrganizer"
     internal const val WRITER_ROLE = "writer"
     internal const val COMMENTER_ROLE = "commenter"
     internal const val READER_ROLE = "reader"

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/mapper/DataMappers.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/mapper/DataMappers.kt
@@ -27,10 +27,8 @@ import com.openmobilehub.android.storage.core.utils.fromRFC3339StringToDate
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.ANYONE_TYPE
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.COMMENTER_ROLE
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.DOMAIN_TYPE
-import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.FILE_ORGANIZER_ROLE
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.FOLDER_MIME_TYPE
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.GROUP_TYPE
-import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.ORGANIZER_ROLE
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.OWNER_ROLE
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.READER_ROLE
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants.USER_TYPE
@@ -162,8 +160,6 @@ internal fun PermissionResponse.toPermission(): OmhPermission? {
 
 internal fun String.stringToRole(): OmhPermissionRole? = when (this) {
     OWNER_ROLE -> OmhPermissionRole.OWNER
-    ORGANIZER_ROLE -> OmhPermissionRole.ORGANIZER
-    FILE_ORGANIZER_ROLE -> OmhPermissionRole.FILE_ORGANIZER
     WRITER_ROLE -> OmhPermissionRole.WRITER
     COMMENTER_ROLE -> OmhPermissionRole.COMMENTER
     READER_ROLE -> OmhPermissionRole.READER
@@ -172,8 +168,6 @@ internal fun String.stringToRole(): OmhPermissionRole? = when (this) {
 
 internal fun OmhPermissionRole.toStringRole(): String = when (this) {
     OmhPermissionRole.OWNER -> OWNER_ROLE
-    OmhPermissionRole.ORGANIZER -> ORGANIZER_ROLE
-    OmhPermissionRole.FILE_ORGANIZER -> FILE_ORGANIZER_ROLE
     OmhPermissionRole.WRITER -> WRITER_ROLE
     OmhPermissionRole.COMMENTER -> COMMENTER_ROLE
     OmhPermissionRole.READER -> READER_ROLE


### PR DESCRIPTION
## Summary
We [do not support Shared Drives](https://developers.google.com/drive/api/guides/enable-shareddrives) so I have removed the permissions specific to it.
I also changed the sample app to not to allow create or edit permissions with OWNER type - file ownership transfer is outside of the create/edit flow.

## Demo
https://github.com/openmobilehub/android-omh-storage/assets/28648651/7299e4c3-1aac-44c5-b9b6-b3632b0a15a9

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: n/a
