### PR TITLE
fix: check if permanently delete is supported

### DIFF
--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/FileViewerViewModel.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/FileViewerViewModel.kt
@@ -24,6 +24,8 @@ import com.openmobilehub.android.storage.core.OmhStorageClient
 import com.openmobilehub.android.storage.core.model.OmhFileVersion
 import com.openmobilehub.android.storage.core.model.OmhStorageEntity
 import com.openmobilehub.android.storage.sample.domain.model.FileType
+import com.openmobilehub.android.storage.sample.domain.model.StorageAuthProvider
+import com.openmobilehub.android.storage.sample.domain.repository.SessionRepository
 import com.openmobilehub.android.storage.sample.presentation.BaseViewModel
 import com.openmobilehub.android.storage.sample.presentation.file_viewer.model.DisplayFileType
 import com.openmobilehub.android.storage.sample.presentation.file_viewer.model.FileViewerViewAction
@@ -57,7 +59,8 @@ import java.io.ByteArrayOutputStream
 @HiltViewModel
 class FileViewerViewModel @Inject constructor(
     private val authClient: OmhAuthClient,
-    private val omhStorageClient: OmhStorageClient
+    private val omhStorageClient: OmhStorageClient,
+    sessionRepository: SessionRepository
 ) : BaseViewModel<FileViewerViewState, FileViewerViewEvent>() {
 
     companion object {
@@ -88,6 +91,13 @@ class FileViewerViewModel @Inject constructor(
     private val parentId = StackWithFlow(omhStorageClient.rootFolder)
     private var searchQuery: MutableStateFlow<String?> = MutableStateFlow(null)
     private var forceRefresh: MutableStateFlow<Int> = MutableStateFlow(0)
+
+    private val isPermanentlyDeleteSupported: Boolean =
+        when (sessionRepository.getStorageAuthProvider()) {
+            StorageAuthProvider.GOOGLE -> true
+            StorageAuthProvider.DROPBOX -> false
+            StorageAuthProvider.MICROSOFT -> false
+        }
 
     init {
         viewModelScope.launch {
@@ -366,7 +376,11 @@ class FileViewerViewModel @Inject constructor(
     }
 
     private fun permanentlyDeleteFileEventClicked(event: FileViewerViewEvent.PermanentlyDeleteFileClicked) {
-        setState(FileViewerViewState.ShowPermanentlyDeleteDialog(event.file))
+        if (isPermanentlyDeleteSupported) {
+            setState(FileViewerViewState.ShowPermanentlyDeleteDialog(event.file))
+        } else {
+            toastMessage.postValue("Unsupported operation")
+        }
     }
 
     private fun permanentlyDeleteFileEvent(event: FileViewerViewEvent.PermanentlyDeleteFile) {


### PR DESCRIPTION
## Summary
To avoid overcomplicating the UI, a simple toast is displayed when users try to use the permanently deleted functionality in the sample app on a provider that does not support it.

## Demo

https://github.com/user-attachments/assets/cd3c9f55-d4f4-4e6f-adbf-b80fea28fb58


## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: n/a
