### PR TITLE
fix/OMHD-517: Dropbox update file fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This is the main directory of the mono-repo for Android OMH Storage. If you're s
 | Folder creation              |         ✅          |           ✅          |    ✅    |    ✅   |
 | File creation (by mime type) |         ✅          |           ✅          |    ❌    |    ❌   |
 | File creation (by extension) |         ❌          |           ❌          |    ✅    |    ✅   |
-| File update                  |         ✅          |           ✅          |          |    ✅*  |
+| File update                  |         ✅          |           ✅          |    ✅    |    ✅   |
 | File deletion                |         ✅          |           ✅          |    ✅    |    ✅   |
 | File permanent deletion      |         ✅          |           ✅          |    ❌    |    ❌   |
 | File upload                  |         ✅          |           ✅          |    ✅    |    ✅   |
@@ -66,7 +66,6 @@ This is the main directory of the mono-repo for Android OMH Storage. If you're s
 | File permissions             |         🟨          |           🟨          |    🟨    |    🟨   |
 | File URL                     |         ✅          |           ✅          |    ✅    |    ✅   |
 
-* If existing and updated files are the same, no new version will be added. If the existing file has a different name, the file will be overridden with no previous revisions.
 
 ### File metadata
 

--- a/packages/plugin-dropbox/README.md
+++ b/packages/plugin-dropbox/README.md
@@ -89,6 +89,10 @@ val omhStorageClient = DropboxOmhStorageFactory().getStorageClient(omhAuthClient
 
 Interacting with the Dropbox storage provider follows the same pattern as other storage providers since they all implement the [`OmhStorageClient`](https://miniature-adventure-4gle9ye.pages.github.io/api/packages/core/com.openmobilehub.android.storage.core/-omh-storage-client) interface. This uniformity ensures consistent functionality across different storage providers, so you won’t need to learn new methods regardless of the storage provider you choose! For a comprehensive list of available methods, refer to the [Getting Started](https://miniature-adventure-4gle9ye.pages.github.io/docs/getting-started) guide.
 
+#### Caveats
+
+> When updating a file, if the new file has a different name than the updated file, two additional versions might sometimes appear in the system. One version comes from updating the content of the file, and the other comes from updating the file name. However, this behavior is non-deterministic, and sometimes only one new version is added. This is why it is listed under the Caveats section.
+
 ## License
 
 - See [LICENSE](https://github.com/openmobilehub/android-omh-storage/blob/main/LICENSE)

--- a/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/data/service/DropboxApiService.kt
+++ b/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/data/service/DropboxApiService.kt
@@ -21,6 +21,7 @@ import com.dropbox.core.v2.files.CreateFolderResult
 import com.dropbox.core.v2.files.DeleteResult
 import com.dropbox.core.v2.files.FileMetadata
 import com.dropbox.core.v2.files.ListFolderResult
+import com.dropbox.core.v2.files.ListRevisionsMode
 import com.dropbox.core.v2.files.ListRevisionsResult
 import com.dropbox.core.v2.files.Metadata
 import com.dropbox.core.v2.files.RelocationResult
@@ -67,7 +68,8 @@ internal class DropboxApiService(private val apiClient: DropboxApiClient) {
     }
 
     fun getFileRevisions(fileId: String): ListRevisionsResult {
-        return apiClient.dropboxApiService.files().listRevisions(fileId)
+        return apiClient.dropboxApiService.files().listRevisionsBuilder(fileId)
+            .withMode(ListRevisionsMode.ID).start()
     }
 
     fun downloadFileRevision(

--- a/packages/plugin-dropbox/src/test/java/com/openmobilehub/android/storage/plugin/dropbox/data/service/DropboxApiServiceTest.kt
+++ b/packages/plugin-dropbox/src/test/java/com/openmobilehub/android/storage/plugin/dropbox/data/service/DropboxApiServiceTest.kt
@@ -138,7 +138,7 @@ class DropboxApiServiceTest {
     fun `given apiClient returns ListRevisionResult, when getting the file versions list, then return ListRevisionResult`() {
         // Arrange
         every {
-            apiClient.dropboxApiService.files().listRevisions(any<String>())
+            apiClient.dropboxApiService.files().listRevisionsBuilder(any<String>()).withMode(any()).start()
         } returns listRevisionsResult
 
         // Act


### PR DESCRIPTION
## Summary

This PR fixes dropbox update feature by updating the `getFileRevisions` to work with ids instead of paths. 

## Demo

https://github.com/user-attachments/assets/c042c4fb-0008-4c7c-bf95-df1d5c69b730

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-517](https://callstackio.atlassian.net/browse/OMHD-517)
