### PR TITLE
hotfix: missing proguard rule for MicrosoftAuthLibrary

### DIFF
--- a/apps/storage-sample/proguard-rules.pro
+++ b/apps/storage-sample/proguard-rules.pro
@@ -24,3 +24,6 @@
 -dontwarn aQute.bnd.annotation.spi.ServiceProvider
 -dontwarn javax.xml.stream.**
 -dontwarn org.codehaus.stax2.validation.**
+
+# Hotfix: this rule should be declared by the plugin itself
+-keep class com.openmobilehub.android.auth.plugin.microsoft.ApiService { *; }


### PR DESCRIPTION
## Summary
I am adding this as a hotfix so not to block the Q&A team - currently the release builds are crashing due to obfuscated class.  
This will be removed once a new version of omh-auth:plugin-microsoft is released [that fixes it on the plugin level](https://github.com/openmobilehub/android-omh-auth/pull/90), but it can take some additional time as [the CI is failing there](https://github.com/openmobilehub/android-omh-auth/commits/main/) for some time now 😰 

## Demo
n/a

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: n/a
