### PR TITLE
fix: Dropbox permissions bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,14 @@ This is the main directory of the mono-repo for Android OMH Storage. If you're s
 | Role      | Google Drive (GMS) | Google Drive (non-GMS) | OneDrive | Dropbox |
 |-----------|:------------------:|:----------------------:|:--------:|:-------:|
 | OWNER     |         ✅         |           ✅           |    ✅    |    ✅   |
-| WRITER    |         ✅         |           ✅           |    ✅    |    ✅   |
+| WRITER    |         ✅         |           ✅           |    ✅    |    🟨   |
 | COMMENTER |         ✅         |           ✅           |    ❌    |    ✅   |
 | READER    |         ✅         |           ✅           |    ✅    |    🟨   |
 
 > Dropbox: when trying to create permissions with role `READER`, Dropbox will
 > throw `AddFileMemberErrorException` with user message: `viewer_no_comment isn’t yet supported`.
+> Folders support the role `WRITER` regardless of their location, but files must be in the root 
+> folder. File can inherit `WRITER` permission from its parent folder.
 
 [`OmhPermissionRecipient`](https://miniature-adventure-4gle9ye.pages.github.io/api/packages/core/com.openmobilehub.android.storage.core.model/-omh-permission-recipient)
 

--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/create/CreatePermissionDialog.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/create/CreatePermissionDialog.kt
@@ -56,7 +56,6 @@ class CreatePermissionDialog : DialogFragment() {
             false
         ).also {
             binding = it
-            viewModel.setup(parentViewModel.file)
             setupBinding()
         }.root
     }

--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/create/CreatePermissionViewModel.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/create/CreatePermissionViewModel.kt
@@ -21,12 +21,10 @@ import androidx.lifecycle.viewModelScope
 import com.openmobilehub.android.storage.core.model.OmhCreatePermission
 import com.openmobilehub.android.storage.core.model.OmhPermissionRole
 import com.openmobilehub.android.storage.core.model.OmhPermissionRecipient
-import com.openmobilehub.android.storage.core.model.OmhStorageEntity
 import com.openmobilehub.android.storage.sample.domain.model.StorageAuthProvider
 import com.openmobilehub.android.storage.sample.domain.repository.SessionRepository
 import com.openmobilehub.android.storage.sample.presentation.file_viewer.dialog.permissions.create.model.CreatePermissionsViewAction
 import com.openmobilehub.android.storage.sample.presentation.file_viewer.dialog.permissions.create.model.PermissionType
-import com.openmobilehub.android.storage.sample.util.isFile
 import com.openmobilehub.android.storage.sample.util.isValidEmail
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -59,15 +57,6 @@ class CreatePermissionViewModel @Inject constructor(
         )
     }
 
-    fun setup(file: OmhStorageEntity) {
-        if (storageAuthProvider == StorageAuthProvider.DROPBOX && file.isFile()) {
-            // Dropbox does not allow to grant writer permissions to files, only folders
-            disabledRoles = disabledRoles.toMutableSet().apply {
-                add(OmhPermissionRole.WRITER)
-            }
-        }
-    }
-
     private val _role: MutableStateFlow<OmhPermissionRole> =
         MutableStateFlow(
             when (storageAuthProvider) {
@@ -91,7 +80,8 @@ class CreatePermissionViewModel @Inject constructor(
         StorageAuthProvider.GOOGLE -> emptySet()
         StorageAuthProvider.DROPBOX -> setOf(
             PermissionType.ANYONE,
-            PermissionType.DOMAIN
+            PermissionType.DOMAIN,
+            PermissionType.GROUP,
         )
 
         StorageAuthProvider.MICROSOFT -> setOf(

--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/edit/EditPermissionDialog.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/edit/EditPermissionDialog.kt
@@ -49,7 +49,6 @@ class EditPermissionDialog : DialogFragment(), AdapterView.OnItemSelectedListene
             false
         ).also {
             binding = it
-            viewModel.setup(parentViewModel.file)
             setupBinding()
         }.root
     }

--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/edit/EditPermissionViewModel.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/edit/EditPermissionViewModel.kt
@@ -39,7 +39,7 @@ class EditPermissionViewModel @Inject constructor(
         StorageAuthProvider.DROPBOX -> OmhPermissionRole.COMMENTER
         StorageAuthProvider.MICROSOFT -> OmhPermissionRole.READER
     }
-    var disabledRoles: Set<OmhPermissionRole> = when (storageAuthProvider) {
+    val disabledRoles: Set<OmhPermissionRole> = when (storageAuthProvider) {
         StorageAuthProvider.GOOGLE -> emptySet()
         StorageAuthProvider.DROPBOX -> setOf(
             OmhPermissionRole.READER
@@ -48,15 +48,6 @@ class EditPermissionViewModel @Inject constructor(
         StorageAuthProvider.MICROSOFT -> setOf(
             OmhPermissionRole.COMMENTER
         )
-    }
-
-    fun setup(file: OmhStorageEntity) {
-        if (storageAuthProvider == StorageAuthProvider.DROPBOX && file.isFile()) {
-            // Dropbox does not allow to grant writer permissions to files, only folders
-            disabledRoles = disabledRoles.toMutableSet().apply {
-                add(OmhPermissionRole.WRITER)
-            }
-        }
     }
 
     var roleIndex: Int


### PR DESCRIPTION
## Summary
Dropbox:
- Document partially supported WRITER permission
- Dropbox groups don't have emails. To invite a Group, use WithObjectId and provide a group ID. Hence, disable GROUP permission adding from the sample app as it is email-based only.

## Demo
n/a

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-518](https://callstackio.atlassian.net/browse/OMHD-518)
