### PR TITLE
fix: Dropbox WRITER permissions issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,11 @@ This is the main directory of the mono-repo for Android OMH Storage. If you're s
 | COMMENTER |         ✅         |           ✅           |    ❌    |    ✅   |
 | READER    |         ✅         |           ✅           |    ✅    |    🟨   |
 
-> Dropbox: when trying to create permissions with role `READER`, Dropbox will
-> throw `AddFileMemberErrorException` with user message: `viewer_no_comment isn’t yet supported`.
-> Folders support the role `WRITER` regardless of their location, but files must be in the root 
-> folder. File can inherit `WRITER` permission from its parent folder.
+> Dropbox:
+> - Dropbox does not support granting a `READER` role, although it is documented as available in the 
+> API. An exception will be thrown with user message: `viewer_no_comment isn’t yet supported`
+> - Dropbox does not support granting a `WRITER` role to uploaded files. An exception will be thrown
+> with user message: `You don’t have permission to perform this action.`.
 
 [`OmhPermissionRecipient`](https://miniature-adventure-4gle9ye.pages.github.io/api/packages/core/com.openmobilehub.android.storage.core.model/-omh-permission-recipient)
 

--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/FilePermissionsDialog.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/FilePermissionsDialog.kt
@@ -24,6 +24,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -85,6 +86,20 @@ class FilePermissionsDialog : BaseDialog(), FilePermissionAdapter.ItemListener {
 
         binding.getUrl.setOnClickListener {
             viewModel.getWebUrl()
+        }
+
+        binding.caveatsContainer.isVisible = viewModel.permissionCaveats != null
+        binding.caveatsLabel.setOnClickListener {
+            binding.caveatsContent.isVisible = !binding.caveatsContent.isVisible
+            val drawable = ContextCompat.getDrawable(
+                requireContext(),
+                if (binding.caveatsContent.isVisible)
+                    R.drawable.round_arrow_drop_up else R.drawable.round_arrow_drop_down
+            )
+            binding.caveatsLabel.setCompoundDrawablesWithIntrinsicBounds(null, null, drawable, null)
+        }
+        viewModel.permissionCaveats?.let {
+            binding.caveatsContent.text = resources.getString(it)
         }
     }
 

--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/FilePermissionsViewModel.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/permissions/FilePermissionsViewModel.kt
@@ -16,6 +16,7 @@
 
 package com.openmobilehub.android.storage.sample.presentation.file_viewer.dialog.permissions
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.viewModelScope
 import com.openmobilehub.android.storage.core.OmhStorageClient
 import com.openmobilehub.android.storage.core.model.OmhCreatePermission
@@ -67,6 +68,14 @@ class FilePermissionsViewModel @Inject constructor(
             StorageAuthProvider.GOOGLE -> true
             StorageAuthProvider.DROPBOX -> true
             StorageAuthProvider.MICROSOFT -> false
+        }
+
+
+    @StringRes val permissionCaveats: Int? =
+        when (storageAuthProvider) {
+            StorageAuthProvider.GOOGLE -> null
+            StorageAuthProvider.DROPBOX -> R.string.permission_caveats_dropbox
+            StorageAuthProvider.MICROSOFT -> null
         }
 
     fun getPermissions(file: OmhStorageEntity) {

--- a/apps/storage-sample/src/main/res/drawable/round_arrow_drop_down.xml
+++ b/apps/storage-sample/src/main/res/drawable/round_arrow_drop_down.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2023 Open Mobile Hub
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M8.71,11.71l2.59,2.59c0.39,0.39 1.02,0.39 1.41,0l2.59,-2.59c0.63,-0.63 0.18,-1.71 -0.71,-1.71H9.41c-0.89,0 -1.33,1.08 -0.7,1.71z"/>
+    
+</vector>

--- a/apps/storage-sample/src/main/res/drawable/round_arrow_drop_up.xml
+++ b/apps/storage-sample/src/main/res/drawable/round_arrow_drop_up.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2023 Open Mobile Hub
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M8.71,12.29L11.3,9.7c0.39,-0.39 1.02,-0.39 1.41,0l2.59,2.59c0.63,0.63 0.18,1.71 -0.71,1.71H9.41c-0.89,0 -1.33,-1.08 -0.7,-1.71z"/>
+    
+</vector>

--- a/apps/storage-sample/src/main/res/layout/dialog_file_permission.xml
+++ b/apps/storage-sample/src/main/res/layout/dialog_file_permission.xml
@@ -11,13 +11,68 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/caveatsContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="visible"
+            app:layout_constraintTop_toBottomOf="@id/header"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginTop="16dp">
+
+        <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                android:id="@+id/caveatsDivider"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+                android:id="@+id/caveatsLabel"
+                android:layout_width="match_parent"
+                android:text="@string/permission_caveats_label"
+                android:layout_marginTop="16dp"
+                android:layout_height="wrap_content"
+                app:drawableRightCompat="@drawable/round_arrow_drop_down"
+                app:layout_constrainedHeight="true"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/caveatsDivider"
+                android:layout_marginStart="24dp"
+                android:layout_marginEnd="24dp" />
+
+        <TextView
+                android:id="@+id/caveatsContent"
+                android:layout_width="match_parent"
+                app:layout_constrainedHeight="true"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:layout_constraintTop_toBottomOf="@+id/caveatsLabel"
+                android:layout_marginStart="24dp"
+                android:layout_marginEnd="24dp" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginTop="16dp"
+            app:layout_constraintTop_toBottomOf="@id/caveatsContainer"
+            android:id="@+id/dividerTop"/>
+
     <com.google.android.material.button.MaterialButton
             android:id="@+id/add"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/permission_add"
             style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-            app:layout_constraintTop_toBottomOf="@+id/header"
+            app:layout_constraintTop_toBottomOf="@id/dividerTop"
             app:layout_constraintStart_toStartOf="parent"
             android:layout_marginStart="24dp"
             android:layout_marginTop="16dp" />
@@ -31,16 +86,7 @@
             app:layout_constraintTop_toBottomOf="@+id/add"
             app:layout_constraintStart_toStartOf="parent"
             android:layout_marginStart="24dp"
-            android:layout_marginTop="16dp" />
-
-    <com.google.android.material.divider.MaterialDivider
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@+id/getUrl"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:id="@+id/materialDivider"
-            android:layout_marginTop="16dp" />
+            android:layout_marginTop="8dp" />
 
     <ProgressBar
             android:id="@+id/progressBar"
@@ -49,8 +95,17 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/materialDivider"
+            app:layout_constraintTop_toBottomOf="@+id/getUrl"
             app:layout_constraintVertical_bias="0.0" />
+
+    <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@+id/getUrl"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:id="@+id/dividerBottom"
+            android:layout_marginTop="16dp" />
 
     <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/permissions"
@@ -60,7 +115,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@+id/materialDivider"
+            app:layout_constraintTop_toBottomOf="@+id/dividerBottom"
             app:layout_constraintVertical_bias="0.0" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/apps/storage-sample/src/main/res/layout/row_dialog_header.xml
+++ b/apps/storage-sample/src/main/res/layout/row_dialog_header.xml
@@ -36,6 +36,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginStart="24dp"
             android:layout_marginEnd="24dp"
+            android:textAppearance="@android:style/TextAppearance.Material.Body1"
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintTop_toBottomOf="@+id/title"
             android:layout_marginTop="24dp" />

--- a/apps/storage-sample/src/main/res/values/strings.xml
+++ b/apps/storage-sample/src/main/res/values/strings.xml
@@ -90,5 +90,13 @@
     <string name="permission_label_send_notification_email">Send notification email</string>
     <string name="permission_email_required_error">A valid email is required.</string>
     <string name="permission_domain_required_error">Domain is required.</string>
+    <string name="permission_caveats_label">Caveats</string>
+    <string name="permission_caveats_dropbox">- Dropbox folders have two types: folder and shared folder.
+\n- A folder must be a shared folder for Dropbox to provide permissions, including providing <i>OWNER</i> permission.
+\n- Adding permission will make a folder a shared folder.
+\n- <i>GET URL</i> only provides links for shared folders.
+\n- Dropbox does not support granting a <i>WRITER</i> role to uploaded files. An exception will be thrown with user message: `You don’t have permission to perform this action.`.
+\n- Dropbox does not support deleting inherited permissions.
+    </string>
 
 </resources>


### PR DESCRIPTION
## Summary
Dropbox does not support granting a `WRITER` role to uploaded files via their Web App and if tried via API, an exception will be thrown with user message: `You don’t have permission to perform this action.`. Note that this does not applies for files that were created or folders.

This PR includes:
- Updated documentation - I previously misunderstood the behaviour and documented it incorrectly.
- A Caveats section in the permission dialogue explaining quirks and unintuitive behaviours of Dropbox permissions.
- Fixes regarding some of the `DropboxFileRepository` methods not mapping exceptions.

## Demo

https://github.com/user-attachments/assets/c6c6ddbe-5a82-47f4-a898-53cbba977080



## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-347](https://callstackio.atlassian.net/browse/OMHD-347)
