### PR TITLE
fix/OMHD-525: Empty file upload

### DIFF
--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/di/StorageModule.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/di/StorageModule.kt
@@ -61,7 +61,7 @@ class StorageModule {
         omhAuthClient: OmhAuthClient
     ): OmhStorageClient {
         return OmhStorageProvider.Builder()
-            .addGmsPath(GoogleDriveGmsConstants.IMPLEMENTATION_PATH)
+            .addGmsPath(GoogleDriveNonGmsConstants.IMPLEMENTATION_PATH)
             .addNonGmsPath(GoogleDriveNonGmsConstants.IMPLEMENTATION_PATH)
             .build()
             .provideStorageClient(omhAuthClient, context)

--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/di/StorageModule.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/di/StorageModule.kt
@@ -61,7 +61,7 @@ class StorageModule {
         omhAuthClient: OmhAuthClient
     ): OmhStorageClient {
         return OmhStorageProvider.Builder()
-            .addGmsPath(GoogleDriveNonGmsConstants.IMPLEMENTATION_PATH)
+            .addGmsPath(GoogleDriveGmsConstants.IMPLEMENTATION_PATH)
             .addNonGmsPath(GoogleDriveNonGmsConstants.IMPLEMENTATION_PATH)
             .build()
             .provideStorageClient(omhAuthClient, context)

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/GoogleDriveNonGmsOmhStorageClient.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/GoogleDriveNonGmsOmhStorageClient.kt
@@ -107,7 +107,7 @@ internal class GoogleDriveNonGmsOmhStorageClient private constructor(
     override suspend fun updateFile(
         localFileToUpload: File,
         fileId: String
-    ): OmhStorageEntity.OmhFile? {
+    ): OmhStorageEntity.OmhFile {
         return fileRepository.updateFile(localFileToUpload, fileId)
     }
 

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
@@ -147,7 +147,7 @@ internal class NonGmsFileRepository(
         parentId: String?
     ): OmhStorageEntity? {
         if (localFileToUpload.length() < 1) {
-            return smallUploadFile(localFileToUpload, parentId)
+            return uploadSmallFile(localFileToUpload, parentId)
         } else {
             val uploadUrl = initializeResumableUpload(localFileToUpload, parentId)
             return uploadFileChunks(uploadUrl, localFileToUpload)
@@ -159,7 +159,7 @@ internal class NonGmsFileRepository(
         fileId: String
     ): OmhStorageEntity.OmhFile {
         if (localFileToUpload.length() < 1) {
-            return simplyUpdateFile(localFileToUpload, fileId) as OmhStorageEntity.OmhFile
+            return smallFileUpdate(localFileToUpload, fileId) as OmhStorageEntity.OmhFile
         } else {
             val uploadUrl = initializeResumableUpdate(localFileToUpload, fileId)
             return uploadFileChunks(uploadUrl, localFileToUpload) as OmhStorageEntity.OmhFile
@@ -281,7 +281,7 @@ internal class NonGmsFileRepository(
     }
 
     @VisibleForTesting
-    suspend fun smallUploadFile(
+    suspend fun uploadSmallFile(
         localFileToUpload: File,
         parentId: String?
     ): OmhStorageEntity? {
@@ -320,7 +320,7 @@ internal class NonGmsFileRepository(
     }
 
     @VisibleForTesting
-    suspend fun simplyUpdateFile(
+    suspend fun smallFileUpdate(
         localFileToUpload: File,
         fileId: String
     ): OmhStorageEntity? {

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
@@ -147,7 +147,7 @@ internal class NonGmsFileRepository(
         parentId: String?
     ): OmhStorageEntity? {
         if (localFileToUpload.length() < 1) {
-            return simplyUploadFile(localFileToUpload, parentId)
+            return smallUploadFile(localFileToUpload, parentId)
         } else {
             val uploadUrl = initializeResumableUpload(localFileToUpload, parentId)
             return uploadFileChunks(uploadUrl, localFileToUpload)
@@ -281,7 +281,7 @@ internal class NonGmsFileRepository(
     }
 
     @VisibleForTesting
-    suspend fun simplyUploadFile(
+    suspend fun smallUploadFile(
         localFileToUpload: File,
         parentId: String?
     ): OmhStorageEntity? {

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/service/GoogleStorageApiService.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/service/GoogleStorageApiService.kt
@@ -25,6 +25,7 @@ import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.PermissionsListResponse
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.RevisionListRemoteResponse
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.WebUrlResponse
+import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Response
@@ -32,9 +33,11 @@ import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.Multipart
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.PUT
+import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
 import retrofit2.http.Url
@@ -111,10 +114,22 @@ internal interface GoogleStorageApiService {
         @Query(QUERY_MIME_TYPE) mimeType: String
     ): Response<ResponseBody>
 
+    @Multipart
+    @POST(UPLOAD_FILES_PARTICLE)
+    suspend fun uploadFile(
+        @Part metadata: MultipartBody.Part,
+        @Part file: MultipartBody.Part,
+        @Query("uploadType") uploadType: String = "multipart",
+        @Query(QUERY_FIELDS) fields: String = QUERY_REQUESTED_FIELDS,
+    ): Response<FileRemoteResponse>
+
+    @Multipart
     @PATCH("$UPLOAD_FILES_PARTICLE/{$FILE_ID}")
     suspend fun updateFile(
-        @Body filePart: RequestBody,
         @Path(FILE_ID) fileId: String,
+        @Part metadata: MultipartBody.Part,
+        @Part file: MultipartBody.Part,
+        @Query("uploadType") uploadType: String = "multipart",
         @Query(QUERY_FIELDS) fields: String = QUERY_REQUESTED_FIELDS,
     ): Response<FileRemoteResponse>
 
@@ -178,6 +193,14 @@ internal interface GoogleStorageApiService {
 
     @POST(UPLOAD_FILES_PARTICLE)
     suspend fun postResumableUpload(
+        @Body body: RequestBody,
+        @Query(QUERY_UPLOAD_TYPE) uploadType: String = "resumable",
+        @Query(QUERY_FIELDS) fields: String = QUERY_REQUESTED_FIELDS,
+    ): Response<ResponseBody>
+
+    @PUT("$UPLOAD_FILES_PARTICLE/{$FILE_ID}")
+    suspend fun putResumableUpload(
+        @Path(FILE_ID) fileId: String,
         @Body body: RequestBody,
         @Query(QUERY_UPLOAD_TYPE) uploadType: String = "resumable",
         @Query(QUERY_FIELDS) fields: String = QUERY_REQUESTED_FIELDS,

--- a/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepositoryTest.kt
+++ b/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepositoryTest.kt
@@ -947,7 +947,7 @@ internal class NonGmsFileRepositoryTest {
         }
 
     @Test
-    fun `given an empty file and parentId, when simplyUploadFile is success, then return OmhStorageEntity`() =
+    fun `given an empty file and parentId, when smallUploadFile is success, then return OmhStorageEntity`() =
         runTest {
             val fileSize = 0
             every { file.length() } returns fileSize.toLong()
@@ -964,13 +964,13 @@ internal class NonGmsFileRepositoryTest {
                 testFileRemote
             )
 
-            val result = fileRepositoryImpl.simplyUploadFile(file, TEST_FILE_PARENT_ID)
+            val result = fileRepositoryImpl.smallUploadFile(file, TEST_FILE_PARENT_ID)
 
             assertEquals(testOmhFile, result)
         }
 
     @Test(expected = OmhStorageException.ApiException::class)
-    fun `given an empty file and parentId, when simplyUploadFile fails, then ApiException is thrown`() =
+    fun `given an empty file and parentId, when smallUploadFile fails, then ApiException is thrown`() =
         runTest {
             val fileSize = 0
             every { file.length() } returns fileSize.toLong()
@@ -988,7 +988,7 @@ internal class NonGmsFileRepositoryTest {
                 responseBody
             )
 
-            fileRepositoryImpl.simplyUploadFile(file, TEST_FILE_PARENT_ID)
+            fileRepositoryImpl.smallUploadFile(file, TEST_FILE_PARENT_ID)
         }
 
     @Test
@@ -1035,6 +1035,6 @@ internal class NonGmsFileRepositoryTest {
                 responseBody
             )
 
-            fileRepositoryImpl.simplyUploadFile(file, TEST_FILE_ID)
+            fileRepositoryImpl.smallUploadFile(file, TEST_FILE_ID)
         }
 }

--- a/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepositoryTest.kt
+++ b/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepositoryTest.kt
@@ -947,7 +947,7 @@ internal class NonGmsFileRepositoryTest {
         }
 
     @Test
-    fun `given an empty file and parent Id, when simplyUploadFile is success, then return OmhStorageEntity`() =
+    fun `given an empty file and parentId, when simplyUploadFile is success, then return OmhStorageEntity`() =
         runTest {
             val fileSize = 0
             every { file.length() } returns fileSize.toLong()
@@ -970,7 +970,7 @@ internal class NonGmsFileRepositoryTest {
         }
 
     @Test(expected = OmhStorageException.ApiException::class)
-    fun `given an empty file and parent Id, when simplyUploadFile fails, then ApiException is thrown`() =
+    fun `given an empty file and parentId, when simplyUploadFile fails, then ApiException is thrown`() =
         runTest {
             val fileSize = 0
             every { file.length() } returns fileSize.toLong()
@@ -992,7 +992,7 @@ internal class NonGmsFileRepositoryTest {
         }
 
     @Test
-    fun `given an empty file and parent Id, when simplyUpdateFile is success, then return OmhStorageEntity`() =
+    fun `given an empty file and fileId, when simplyUpdateFile is success, then return OmhStorageEntity`() =
         runTest {
             val fileSize = 0
             every { file.length() } returns fileSize.toLong()
@@ -1016,7 +1016,7 @@ internal class NonGmsFileRepositoryTest {
         }
 
     @Test(expected = OmhStorageException.ApiException::class)
-    fun `given an empty file and parent Id, when simplyUpdateFile fails, then ApiException is thrown`() =
+    fun `given an empty file and fileId, when simplyUpdateFile fails, then ApiException is thrown`() =
         runTest {
             val fileSize = 0
             every { file.length() } returns fileSize.toLong()

--- a/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepositoryTest.kt
+++ b/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepositoryTest.kt
@@ -947,7 +947,7 @@ internal class NonGmsFileRepositoryTest {
         }
 
     @Test
-    fun `given an empty file and parentId, when smallUploadFile is success, then return OmhStorageEntity`() =
+    fun `given an empty file and parentId, when uploadSmallFile is success, then return OmhStorageEntity`() =
         runTest {
             val fileSize = 0
             every { file.length() } returns fileSize.toLong()
@@ -964,13 +964,13 @@ internal class NonGmsFileRepositoryTest {
                 testFileRemote
             )
 
-            val result = fileRepositoryImpl.smallUploadFile(file, TEST_FILE_PARENT_ID)
+            val result = fileRepositoryImpl.uploadSmallFile(file, TEST_FILE_PARENT_ID)
 
             assertEquals(testOmhFile, result)
         }
 
     @Test(expected = OmhStorageException.ApiException::class)
-    fun `given an empty file and parentId, when smallUploadFile fails, then ApiException is thrown`() =
+    fun `given an empty file and parentId, when uploadSmallFile fails, then ApiException is thrown`() =
         runTest {
             val fileSize = 0
             every { file.length() } returns fileSize.toLong()
@@ -988,11 +988,11 @@ internal class NonGmsFileRepositoryTest {
                 responseBody
             )
 
-            fileRepositoryImpl.smallUploadFile(file, TEST_FILE_PARENT_ID)
+            fileRepositoryImpl.uploadSmallFile(file, TEST_FILE_PARENT_ID)
         }
 
     @Test
-    fun `given an empty file and fileId, when simplyUpdateFile is success, then return OmhStorageEntity`() =
+    fun `given an empty file and fileId, when smallFileUpdate is success, then return OmhStorageEntity`() =
         runTest {
             val fileSize = 0
             every { file.length() } returns fileSize.toLong()
@@ -1010,13 +1010,13 @@ internal class NonGmsFileRepositoryTest {
                 testFileRemote
             )
 
-            val result = fileRepositoryImpl.simplyUpdateFile(file, TEST_FILE_ID)
+            val result = fileRepositoryImpl.smallFileUpdate(file, TEST_FILE_ID)
 
             assertEquals(testOmhFile, result)
         }
 
     @Test(expected = OmhStorageException.ApiException::class)
-    fun `given an empty file and fileId, when simplyUpdateFile fails, then ApiException is thrown`() =
+    fun `given an empty file and fileId, when smallFileUpdate fails, then ApiException is thrown`() =
         runTest {
             val fileSize = 0
             every { file.length() } returns fileSize.toLong()
@@ -1035,6 +1035,6 @@ internal class NonGmsFileRepositoryTest {
                 responseBody
             )
 
-            fileRepositoryImpl.smallUploadFile(file, TEST_FILE_ID)
+            fileRepositoryImpl.uploadSmallFile(file, TEST_FILE_ID)
         }
 }

--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveApiService.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveApiService.kt
@@ -167,6 +167,7 @@ internal class OneDriveApiService(private val apiClient: OneDriveApiClient) {
         path: String,
         conflictBehavior: String = "rename"
     ) {
+        // https://github.com/microsoftgraph/msgraph-sdk-java/blob/beae78c1ffc0c67a6a97651060c23a1287973997/docs/upgrade-to-v6.md#upload-a-small-file-with-conflictbehavior-set
         val inputStream = file.toInputStream()
 
         val requestInformation = apiClient.graphServiceClient.drives()

--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveApiService.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveApiService.kt
@@ -29,8 +29,8 @@ import com.openmobilehub.android.storage.core.model.OmhStorageException
 import com.openmobilehub.android.storage.core.utils.toInputStream
 import com.openmobilehub.android.storage.plugin.onedrive.OneDriveConstants
 import java.io.File
-import java.io.FileInputStream
 import java.io.InputStream
+import java.net.URI
 import javax.net.ssl.HttpsURLConnection.HTTP_UNAUTHORIZED
 
 @Suppress("TooManyFunctions")
@@ -43,7 +43,11 @@ internal class OneDriveApiService(private val apiClient: OneDriveApiClient) {
             .byDriveItemId(parentId).children().get().value
     }
 
-    fun uploadFile(file: File, path: String, conflictBehavior: String = "rename"): DriveItem? {
+    fun resumableUploadFile(
+        file: File,
+        path: String,
+        conflictBehavior: String = "rename"
+    ): DriveItem? {
         val fileStream = file.toInputStream()
 
         val uploadSessionRequest = CreateUploadSessionPostRequestBody().apply {
@@ -158,19 +162,26 @@ internal class OneDriveApiService(private val apiClient: OneDriveApiClient) {
             )
     }
 
-    fun createNewFile(
-        fileName: String,
-        parentId: String,
-        inputStream: FileInputStream
-    ): DriveItem? {
-        return apiClient.graphServiceClient.drives()
+    fun uploadFile(
+        file: File,
+        path: String,
+        conflictBehavior: String = "rename"
+    ) {
+        val inputStream = file.toInputStream()
+
+        val requestInformation = apiClient.graphServiceClient.drives()
             .byDriveId(driveId)
             .items()
-            .byDriveItemId(parentId)
-            .children()
-            .byDriveItemId1(fileName)
+            .byDriveItemId(path)
             .content()
-            .put(inputStream)
+            .toPutRequestInformation(inputStream)
+
+        val uriIncludesConflictBehavior =
+            URI(requestInformation.uri.toString() + "?@microsoft.graph.conflictBehavior=$conflictBehavior")
+        requestInformation.uri = uriIncludesConflictBehavior
+
+        apiClient.graphServiceClient.requestAdapter
+            .sendPrimitive(requestInformation, null, InputStream::class.java)
     }
 
     fun updateFileMetadata(fileId: String, driveItem: DriveItem): DriveItem {

--- a/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/data/repository/OneDriveFileRepositoryTest.kt
+++ b/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/data/repository/OneDriveFileRepositoryTest.kt
@@ -207,7 +207,7 @@ class OneDriveFileRepositoryTest {
     }
 
     @Test
-    fun `given an api service returns DriveItem, when uploading empty the file, then returns OmhFile`() {
+    fun `given an api service returns DriveItem, when uploading the empty file, then returns OmhFile`() {
         // Arrange
         every { apiService.uploadFile(any(), any()) } just runs
         every { apiService.getFile(any()) } returns driveItem

--- a/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveRestApiServiceTest.kt
+++ b/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveRestApiServiceTest.kt
@@ -371,7 +371,7 @@ class OneDriveRestApiServiceTest {
     }
 
     @Test
-    fun `given apiClient, when uploading a new file, `() {
+    fun `given apiClient, when uploading a file, sendPrimitive is called `() {
         // Arrange
         every {
             apiClient.graphServiceClient.drives().byDriveId(any()).items().byDriveItemId(any()).content().toPutRequestInformation(


### PR DESCRIPTION
## Summary

This PR:
- fixes OneDrive empty file upload and update by adding support for non-resumable file upload for empty files
- fixes Google non-gms file upload/update by adding support for non-resumable file upload/update for empty files
- improves Google non-gms file update by refactoring the solution from combination of (updateMetadata + media upload) to resumable upload or multipart upload

## Demo
_Non-GMS provider on GMS device was forced with code_

https://github.com/user-attachments/assets/23b3763e-3f27-4d0d-9112-aeb9977c5693

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-525](https://callstackio.atlassian.net/browse/OMHD-525)
