### PR TITLE
Add API to get storage usage and quota

### DIFF
--- a/packages/core/src/main/java/com/openmobilehub/android/storage/core/OmhStorageClient.kt
+++ b/packages/core/src/main/java/com/openmobilehub/android/storage/core/OmhStorageClient.kt
@@ -285,4 +285,18 @@ abstract class OmhStorageClient protected constructor(
      * @return Provider SDK instance that should be type casted to access underlying provider's API
      */
     abstract fun getProviderSdk(): Any
+
+    /**
+     * This method returns the total size used at the storage provider.
+     *
+     * @return total file sizes reported by the storage provider
+     */
+    abstract suspend fun getStorageUsage(): Long
+
+    /**
+     * This method returns the storage quota available at the storage provider.
+     *
+     * @return storage quota available, or -1 if unlimited
+     */
+    abstract suspend fun getStorageQuota(): Long
 }

--- a/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/DropboxOmhStorageClient.kt
+++ b/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/DropboxOmhStorageClient.kt
@@ -180,4 +180,12 @@ internal class DropboxOmhStorageClient @VisibleForTesting internal constructor(
     }
 
     override fun getProviderSdk(): DbxClientV2 = repository.apiService.apiClient.dropboxApiService
+
+    override suspend fun getStorageUsage(): Long {
+        return repository.getStorageUsage()
+    }
+
+    override suspend fun getStorageQuota(): Long {
+        return repository.getStorageQuota()
+    }
 }

--- a/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/data/repository/DropboxFileRepository.kt
+++ b/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/data/repository/DropboxFileRepository.kt
@@ -408,6 +408,29 @@ internal class DropboxFileRepository(
         }
     }
 
+    fun getStorageUsage(): Long {
+        try {
+            return apiService.getSpaceUsage().used
+        } catch (exception: DbxException) {
+            throw ExceptionMapper.toOmhApiException(exception)
+        }
+    }
+
+    fun getStorageQuota(): Long {
+        try {
+            val spaceAllocation = apiService.getSpaceUsage().allocation
+            return if (spaceAllocation.isIndividual) {
+                spaceAllocation.individualValue.allocated
+            } else if (spaceAllocation.isTeam) {
+                spaceAllocation.teamValue.allocated
+            } else {
+                -1L // For OTHER
+            }
+        } catch (exception: DbxException) {
+            throw ExceptionMapper.toOmhApiException(exception)
+        }
+    }
+
     private fun getFilePermissions(fileId: String): List<OmhPermission> {
         val result = apiService.getFilePermissions(fileId)
 

--- a/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/data/service/DropboxApiService.kt
+++ b/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/data/service/DropboxApiService.kt
@@ -38,6 +38,7 @@ import com.dropbox.core.v2.sharing.ShareFolderJobStatus
 import com.dropbox.core.v2.sharing.ShareFolderLaunch
 import com.dropbox.core.v2.sharing.SharedFileMembers
 import com.dropbox.core.v2.sharing.SharedFolderMembers
+import com.dropbox.core.v2.users.SpaceUsage
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 
@@ -223,5 +224,9 @@ internal class DropboxApiService(internal val apiClient: DropboxApiClient) {
                 memberSelector,
                 accessLevel
             )
+    }
+
+    fun getSpaceUsage(): SpaceUsage {
+        return apiClient.dropboxApiService.users().spaceUsage
     }
 }

--- a/packages/plugin-dropbox/src/test/java/com/openmobilehub/android/storage/plugin/dropbox/testdoubles/TestSpaceUsage.kt
+++ b/packages/plugin-dropbox/src/test/java/com/openmobilehub/android/storage/plugin/dropbox/testdoubles/TestSpaceUsage.kt
@@ -1,0 +1,34 @@
+package com.openmobilehub.android.storage.plugin.dropbox.testdoubles
+
+import com.dropbox.core.v2.teamcommon.MemberSpaceLimitType
+import com.dropbox.core.v2.users.IndividualSpaceAllocation
+import com.dropbox.core.v2.users.SpaceAllocation
+import com.dropbox.core.v2.users.SpaceUsage
+import com.dropbox.core.v2.users.TeamSpaceAllocation
+import io.mockk.every
+
+fun SpaceUsage.setUpMockForPersonalAccount() {
+    every { used } returns 100L
+    every { allocation } returns SpaceAllocation.individual(
+        IndividualSpaceAllocation(104857600L)
+    )
+}
+
+fun SpaceUsage.setupMockForTeamAccount() {
+    every { used } returns 1000L
+    // We only read value from getUsed(). Doesn't matter the used value at TeamSpaceAllocation
+    every { allocation } returns SpaceAllocation.team(
+        TeamSpaceAllocation(
+            12345L,
+            1048576000L,
+            100000L,
+            MemberSpaceLimitType.OFF,
+            0L
+        )
+    )
+}
+
+fun SpaceUsage.setupMockForOtherAccount() {
+    every { used } returns 10000L
+    every { allocation } returns SpaceAllocation.OTHER
+}

--- a/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/GoogleDriveGmsOmhStorageClient.kt
+++ b/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/GoogleDriveGmsOmhStorageClient.kt
@@ -179,4 +179,12 @@ internal class GoogleDriveGmsOmhStorageClient private constructor(
     }
 
     override fun getProviderSdk(): Drive = fileRepository.apiService.apiProvider.googleDriveApiService
+
+    override suspend fun getStorageUsage(): Long {
+        return fileRepository.getStorageUsage()
+    }
+
+    override suspend fun getStorageQuota(): Long {
+        return fileRepository.getStorageQuota()
+    }
 }

--- a/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/repository/GmsFileRepository.kt
+++ b/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/repository/GmsFileRepository.kt
@@ -261,4 +261,17 @@ internal class GmsFileRepository(
     } catch (exception: HttpResponseException) {
         throw ExceptionMapper.toOmhApiException(exception)
     }
+
+    fun getStorageUsage(): Long = try {
+        apiService.about().execute().storageQuota.usageInDrive
+    } catch (exception: HttpResponseException) {
+        throw ExceptionMapper.toOmhApiException(exception)
+    }
+
+    fun getStorageQuota(): Long = try {
+        val retval: Long? = apiService.about().execute().storageQuota.limit
+        retval ?: -1L
+    } catch (exception: HttpResponseException) {
+        throw ExceptionMapper.toOmhApiException(exception)
+    }
 }

--- a/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/service/GoogleDriveApiService.kt
+++ b/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/service/GoogleDriveApiService.kt
@@ -170,4 +170,6 @@ internal class GoogleDriveApiService(internal val apiProvider: GoogleDriveApiPro
         .apply {
             fields = WEB_URL_FIELD
         }
+
+    fun about(): Drive.About.Get = apiProvider.googleDriveApiService.about().get()
 }

--- a/packages/plugin-googledrive-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/gms/testdoubles/TestAbout.kt
+++ b/packages/plugin-googledrive-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/gms/testdoubles/TestAbout.kt
@@ -1,0 +1,19 @@
+package com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles
+
+import com.google.api.services.drive.model.About
+import com.google.api.services.drive.model.About.StorageQuota
+import io.mockk.every
+
+fun About.setupQuotaAvailableMock() {
+    every { storageQuota } returns StorageQuota().also {
+        it.usageInDrive = 100
+        it.limit = 104857600
+    }
+}
+
+fun About.setupQuotaUnlimitedMock() {
+    every { storageQuota } returns StorageQuota().also {
+        it.usageInDrive = 100
+        it.limit = null
+    }
+}

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/GoogleDriveNonGmsOmhStorageClient.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/GoogleDriveNonGmsOmhStorageClient.kt
@@ -163,4 +163,12 @@ internal class GoogleDriveNonGmsOmhStorageClient private constructor(
     override fun getProviderSdk(): Any = throw throw UnsupportedOperationException(
         "Google Drive non-gms implementation uses REST API underneath."
     )
+
+    override suspend fun getStorageUsage(): Long {
+        return fileRepository.getStorageUsage()
+    }
+
+    override suspend fun getStorageQuota(): Long {
+        return fileRepository.getStorageQuota()
+    }
 }

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
@@ -505,4 +505,24 @@ internal class NonGmsFileRepository(
             throw response.toApiException()
         }
     }
+
+    suspend fun getStorageUsage(): Long {
+        val response = retrofitImpl.getGoogleStorageApiService().about()
+
+        return if (response.isSuccessful) {
+            response.body()!!.storageQuota.usageInDrive
+        } else {
+            throw response.toApiException()
+        }
+    }
+
+    suspend fun getStorageQuota(): Long {
+        val response = retrofitImpl.getGoogleStorageApiService().about()
+
+        return if (response.isSuccessful) {
+            response.body()!!.storageQuota.limit
+        } else {
+            throw response.toApiException()
+        }
+    }
 }

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/service/GoogleStorageApiService.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/service/GoogleStorageApiService.kt
@@ -19,6 +19,7 @@ package com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.body.CreateFileRequestBody
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.body.CreatePermissionRequestBody
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.body.UpdatePermissionRequestBody
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.AboutResponse
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.FileListRemoteResponse
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.FileRemoteResponse
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.PermissionResponse
@@ -46,6 +47,7 @@ import retrofit2.http.Url
 internal interface GoogleStorageApiService {
 
     companion object {
+        private const val ABOUT = "drive/v3/about"
         private const val FILES_PARTICLE = "drive/v3/files"
         private const val UPLOAD_FILES_PARTICLE = "upload/drive/v3/files"
 
@@ -213,4 +215,7 @@ internal interface GoogleStorageApiService {
         @Header("Content-Range") contentRange: String,
         @Body fileChunk: RequestBody,
     ): Response<FileRemoteResponse>
+
+    @GET(ABOUT)
+    suspend fun about(): Response<AboutResponse>
 }

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/service/response/AboutResponse.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/service/response/AboutResponse.kt
@@ -1,0 +1,20 @@
+package com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response
+
+import androidx.annotation.Keep
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@Keep
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AboutResponse(
+    @JsonProperty("storageQuota") val storageQuota: StorageQuota
+) {
+    @Keep
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class StorageQuota(
+        @JsonProperty("limit") val limit: Long = -1L,
+        @JsonProperty("usageInDrive") val usageInDrive: Long,
+        @JsonProperty("usageInTrash") val usageInTrash: Long,
+        @JsonProperty("usage") val usage: Long
+    )
+}

--- a/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/testdoubles/TestAboutResponse.kt
+++ b/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/testdoubles/TestAboutResponse.kt
@@ -1,0 +1,21 @@
+package com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles
+
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.AboutResponse
+
+internal val aboutResponseWithQuotaImposed = AboutResponse(
+    AboutResponse.StorageQuota(
+        limit = 104857600,
+        usageInDrive = 100,
+        usageInTrash = 5,
+        usage = 99999
+    )
+)
+
+internal val aboutResponseWithUnlimitedQuota = AboutResponse(
+    AboutResponse.StorageQuota(
+        limit = -1L,
+        usageInDrive = 100,
+        usageInTrash = 4,
+        usage = 99998
+    )
+)

--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/OneDriveOmhStorageClient.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/OneDriveOmhStorageClient.kt
@@ -177,4 +177,12 @@ internal class OneDriveOmhStorageClient @VisibleForTesting internal constructor(
 
     override fun getProviderSdk(): GraphServiceClient =
         repository.apiService.apiClient.graphServiceClient
+
+    override suspend fun getStorageUsage(): Long {
+        return repository.getStorageUsage()
+    }
+
+    override suspend fun getStorageQuota(): Long {
+        return repository.getStorageQuota()
+    }
 }

--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/repository/OneDriveFileRepository.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/repository/OneDriveFileRepository.kt
@@ -254,4 +254,16 @@ internal class OneDriveFileRepository(
     } catch (exception: ApiException) {
         throw ExceptionMapper.toOmhApiException(exception)
     }
+
+    fun getStorageUsage(): Long = try {
+        apiService.getDrive().quota.used ?: -1L
+    } catch (exception: ApiException) {
+        throw ExceptionMapper.toOmhApiException(exception)
+    }
+
+    fun getStorageQuota(): Long = try {
+        apiService.getDrive().quota.total ?: -1L
+    } catch (exception: ApiException) {
+        throw ExceptionMapper.toOmhApiException(exception)
+    }
 }

--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveApiService.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveApiService.kt
@@ -20,6 +20,7 @@ import androidx.annotation.VisibleForTesting
 import com.microsoft.graph.drives.item.items.item.createuploadsession.CreateUploadSessionPostRequestBody
 import com.microsoft.graph.drives.item.items.item.invite.InvitePostRequestBody
 import com.microsoft.graph.drives.item.items.item.searchwithq.SearchWithQGetResponse
+import com.microsoft.graph.models.Drive
 import com.microsoft.graph.models.DriveItem
 import com.microsoft.graph.models.DriveItemUploadableProperties
 import com.microsoft.graph.models.DriveItemVersionCollectionResponse
@@ -191,6 +192,10 @@ internal class OneDriveApiService(internal val apiClient: OneDriveApiClient) {
             .items()
             .byDriveItemId(fileId)
             .patch(driveItem)
+    }
+
+    fun getDrive(): Drive {
+        return apiClient.graphServiceClient.drives().byDriveId(driveId).get()
     }
 
     @VisibleForTesting

--- a/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/testdoubles/TestQuota.kt
+++ b/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/testdoubles/TestQuota.kt
@@ -1,0 +1,20 @@
+package com.openmobilehub.android.storage.plugin.onedrive.testdoubles
+
+import com.microsoft.graph.models.Quota
+import io.mockk.every
+
+internal fun Quota.setupMock() {
+    every { used } returns 100L
+    every { total } returns 104857600L
+}
+
+/**
+ * Graph SDK source code indicates these two return values are @Nullable, hence add a test case
+ * to test handling.
+ *
+ * Downstream method should return -1L
+ */
+internal fun Quota.setupNullReturnValueMock() {
+    every { used } returns null
+    every { total } returns null
+}


### PR DESCRIPTION
## Summary
Adds support to get the total file size at specified storage provider.

## Checklist:
- [ ] Documentation is up to date to reflect these changes
- [x] Created Unit tests