### PR TITLE
fix/OMHD-555: Dropbox upload fixes

### DIFF
--- a/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/data/service/DropboxApiService.kt
+++ b/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/data/service/DropboxApiService.kt
@@ -52,14 +52,17 @@ internal class DropboxApiService(internal val apiClient: DropboxApiClient) {
         inputStream: InputStream,
         path: String,
         withAutorename: Boolean = true,
-        writeMode: WriteMode = WriteMode.ADD
+        writeMode: WriteMode = WriteMode.ADD,
+        withStrictConflict: Boolean = true
     ): FileMetadata {
         // withAutorename(true) is used to avoid conflicts with existing files
         // by renaming the uploaded file. It matches the Google Drive API behavior.
+        // withStrictConflict(true) is used to rename the file even if the content is the same.
 
         return apiClient.dropboxApiService.files().uploadBuilder(path)
             .withAutorename(withAutorename)
             .withMode(writeMode)
+            .withStrictConflict(withStrictConflict)
             .uploadAndFinish(inputStream)
     }
 

--- a/packages/plugin-dropbox/src/test/java/com/openmobilehub/android/storage/plugin/dropbox/data/service/DropboxApiServiceTest.kt
+++ b/packages/plugin-dropbox/src/test/java/com/openmobilehub/android/storage/plugin/dropbox/data/service/DropboxApiServiceTest.kt
@@ -109,6 +109,7 @@ class DropboxApiServiceTest {
             apiClient.dropboxApiService.files().uploadBuilder(any())
                 .withAutorename(any())
                 .withMode(any())
+                .withStrictConflict(any())
                 .uploadAndFinish(inputStream)
         } returns metadata
 


### PR DESCRIPTION
## Summary

This PR updates Dropbox behaviour, wo when uploading the same file two or more times, on each upload the new file is created. This behaviour matches Google Drive.

## Demo
Before:

https://github.com/user-attachments/assets/17833621-9e97-4ed1-a2e2-9f746d39405e

After:

https://github.com/user-attachments/assets/e54fc90e-6295-4945-9ba1-291d2b311605

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-555](https://callstackio.atlassian.net/browse/OMHD-555)
