### PR TITLE
fix: add padding bottom to files recycler view

### DIFF
--- a/apps/storage-sample/src/main/res/layout/fragment_file_viewer.xml
+++ b/apps/storage-sample/src/main/res/layout/fragment_file_viewer.xml
@@ -99,6 +99,7 @@
             android:clipToPadding="false"
             android:orientation="vertical"
             android:visibility="gone"
+            android:paddingBottom="64dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Summary
`clipToPadding` was already set to `true` but `paddingBottom` was missing. Although a padding size is fixed, it is big enough to work with three button navigation as well as gesture and in my humble opinion looks good in both cases.

## Demo

https://github.com/user-attachments/assets/b9f4e3ec-7060-4c9f-94a5-2c48a862a471


## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-533](https://callstackio.atlassian.net/browse/OMHD-533)
