### PR TITLE
fix: upload small file fixes

### DIFF
--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
@@ -68,6 +68,7 @@ internal class NonGmsFileRepository(
         private val JSON_MIME_TYPE = "application/json".toMediaTypeOrNull()
 
         private const val UPLOAD_CHUNK_SIZE = 1024 * 1024 * 10 // 10MB
+        private const val SMALL_FILE_SIZE = 1024 * 1024 // 1MB
         private const val DEFAULT_UPLOAD_MIME_TYPE = "application/octet-stream"
         private const val RESUME_INCOMPLETE_STATUS_CODE = 308
     }
@@ -146,7 +147,7 @@ internal class NonGmsFileRepository(
         localFileToUpload: File,
         parentId: String?
     ): OmhStorageEntity? {
-        if (localFileToUpload.length() < 1) {
+        if (localFileToUpload.length() < SMALL_FILE_SIZE) {
             return uploadSmallFile(localFileToUpload, parentId)
         } else {
             val uploadUrl = initializeResumableUpload(localFileToUpload, parentId)
@@ -158,7 +159,7 @@ internal class NonGmsFileRepository(
         localFileToUpload: File,
         fileId: String
     ): OmhStorageEntity.OmhFile {
-        if (localFileToUpload.length() < 1) {
+        if (localFileToUpload.length() < SMALL_FILE_SIZE) {
             return smallFileUpdate(localFileToUpload, fileId) as OmhStorageEntity.OmhFile
         } else {
             val uploadUrl = initializeResumableUpdate(localFileToUpload, fileId)

--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/repository/OneDriveFileRepository.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/repository/OneDriveFileRepository.kt
@@ -51,6 +51,7 @@ internal class OneDriveFileRepository(
 
     companion object {
         private const val PRECONDITION_ERROR_STATUS_CODE = 412
+        private const val SMALL_FILE_SIZE = 1024 * 1024 // 1MB
     }
 
     fun getFilesList(parentId: String): List<OmhStorageEntity> = try {
@@ -64,7 +65,7 @@ internal class OneDriveFileRepository(
     fun uploadFile(localFileToUpload: File, parentId: String): OmhStorageEntity? = try {
         val path = "$parentId:/${localFileToUpload.name}:"
 
-        val driveItem = if (localFileToUpload.length() < 1) {
+        val driveItem = if (localFileToUpload.length() < SMALL_FILE_SIZE) {
             apiService.uploadFile(localFileToUpload, path)
             apiService.getFile(path)
         } else {
@@ -234,7 +235,7 @@ internal class OneDriveFileRepository(
 
     fun updateFile(localFileToUpload: File, fileId: String): OmhStorageEntity {
         try {
-            if (localFileToUpload.length() < 1) {
+            if (localFileToUpload.length() < SMALL_FILE_SIZE) {
                 apiService.uploadFile(localFileToUpload, fileId, "replace")
                 apiService.getFile(fileId)
             } else {

--- a/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/data/repository/OneDriveFileRepositoryTest.kt
+++ b/packages/plugin-onedrive/src/test/java/com/openmobilehub/android/storage/plugin/onedrive/data/repository/OneDriveFileRepositoryTest.kt
@@ -156,7 +156,7 @@ class OneDriveFileRepositoryTest {
             driveItemResponseToOmhStorageEntity
         )
 
-        every { file.length() } returns 100
+        every { file.length() } returns 2 * 1024 * 1024 // 2MB
         every { emptyFile.length() } returns 0
     }
 


### PR DESCRIPTION
## Summary

This PR fixes uploading of small files (on the demo example it's 1 byte file) by changing the small file size treshold from 1 byte to 1 megabyte.

## Demo
Before (timeout):

https://github.com/user-attachments/assets/9d38fdb6-bb54-4560-bb10-19b630def9ca

After:

https://github.com/user-attachments/assets/59e95f21-cde7-49cf-9cce-e9cecb1be263

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-545](https://callstackio.atlassian.net/browse/OMHD-545)
