### PR TITLE
fix/OMHD-562: Empty file download for Google Drive

### DIFF
--- a/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/service/GoogleDriveApiService.kt
+++ b/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/service/GoogleDriveApiService.kt
@@ -79,6 +79,9 @@ internal class GoogleDriveApiService(internal val apiProvider: GoogleDriveApiPro
         .googleDriveApiService
         .files()
         .get(fileId)
+        .apply {
+            fields = QUERY_REQUESTED_FIELDS
+        }
 
     fun getPermission(fileId: String): Drive.Permissions.List = apiProvider
         .googleDriveApiService


### PR DESCRIPTION
## Summary

This PR fixes empty file download for Google GMS provider.

## Demo

https://github.com/user-attachments/assets/b1043c42-80e4-4d3a-a1fe-53f0f5161efa

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests

Closes: [OMHD-562](https://callstackio.atlassian.net/browse/OMHD-562)
