### PR TITLE
OmhStorageClient: add resolvePath() function

### DIFF
--- a/apps/storage-sample/build.gradle.kts
+++ b/apps/storage-sample/build.gradle.kts
@@ -122,6 +122,7 @@ dependencies {
     implementation(Libs.dataStore)
     implementation(Libs.hiltAndroid)
     implementation(Libs.activityKtx)
+    implementation(Libs.slf4jAndroid)
     kapt(Libs.hiltCompiler)
     kapt(Libs.glideCompiler)
 

--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/menu/FileMenuDialog.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/menu/FileMenuDialog.kt
@@ -24,7 +24,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Observer
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.openmobilehub.android.storage.core.model.OmhStorageEntity
 import com.openmobilehub.android.storage.sample.R

--- a/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/menu/FileMenuDialog.kt
+++ b/apps/storage-sample/src/main/java/com/openmobilehub/android/storage/sample/presentation/file_viewer/dialog/menu/FileMenuDialog.kt
@@ -24,6 +24,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.openmobilehub.android.storage.core.model.OmhStorageEntity
 import com.openmobilehub.android.storage.sample.R

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -82,4 +82,8 @@ object Libs {
 
     // Datastore
     val dataStore by lazy { "androidx.datastore:datastore-preferences:${Versions.dataStore}" }
+
+    // SLF4J
+    val slf4jApi by lazy { "org.slf4j:slf4j-api:${Versions.slf4j}" }
+    val slf4jAndroid by lazy { "uk.uuid.slf4j:slf4j-android:${Versions.slf4jAndroid}" }
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -73,4 +73,8 @@ object Versions {
 
     // DataStore
     const val dataStore = "1.1.1"
+
+    // slf4j
+    const val slf4j = "2.0.17"
+    const val slf4jAndroid = "2.0.17-0"
 }

--- a/docs/markdown/getting-started.md
+++ b/docs/markdown/getting-started.md
@@ -257,6 +257,14 @@ Retrieves the storage quota currently in use, in bytes. It is entirely depends o
 val quotaUsed = omhStorageClient.getStorageUsage()
 ```
 
+### Resolve path of a file or folder
+
+Retrieves the ID of the file/folder at specified path on the cloud storage (which the user has access to).
+
+```kotlin
+val fileOrFolderId = omhStorageClient.resolvePath("path/to/the/fileorfolder")
+```
+
 ---
 
 For a more in depth view on the available methods, access the [Reference API](https://openmobilehub.github.io/android-omh-storage/api/packages/core/com.openmobilehub.android.storage.core/-omh-storage-client).

--- a/packages/core/build.gradle.kts
+++ b/packages/core/build.gradle.kts
@@ -20,9 +20,13 @@ dependencies {
     // Play services
     implementation(Libs.googlePlayBase)
 
+    // Logging
+    implementation(Libs.slf4jApi)
+
     // Test
     testImplementation(Libs.junit)
     androidTestImplementation(Libs.androidJunit)
     testImplementation(Libs.mockk)
     testImplementation(Libs.coroutineTesting)
+    testImplementation(Libs.slf4jAndroid)
 }

--- a/packages/core/src/main/java/com/openmobilehub/android/storage/core/OmhStorageClient.kt
+++ b/packages/core/src/main/java/com/openmobilehub/android/storage/core/OmhStorageClient.kt
@@ -277,6 +277,15 @@ abstract class OmhStorageClient protected constructor(
     ): String?
 
     /**
+     * This method retrieves the storage entity at specified path.
+     *
+     * @param path The path of the storage entity
+     *
+     * @return [OmhStorageEntity] or null if not found
+     */
+    abstract suspend fun resolvePath(path: String): OmhStorageEntity?
+
+    /**
      * This method provides an escape hatch to access the provider native SDK. This allows developers
      * to use the underlying provider's API directly, should they need to access a feature of the
      * provider that is not supported by the OMH plugin. Refer to the plugin's advanced documentation

--- a/packages/core/src/main/java/com/openmobilehub/android/storage/core/OmhStorageClient.kt
+++ b/packages/core/src/main/java/com/openmobilehub/android/storage/core/OmhStorageClient.kt
@@ -39,6 +39,8 @@ import com.openmobilehub.android.storage.core.model.OmhPermissionRole
 import com.openmobilehub.android.storage.core.model.OmhStorageEntity
 import com.openmobilehub.android.storage.core.model.OmhStorageException
 import com.openmobilehub.android.storage.core.model.OmhStorageMetadata
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.io.ByteArrayOutputStream
 import java.io.File
 
@@ -46,6 +48,8 @@ import java.io.File
 abstract class OmhStorageClient protected constructor(
     protected val authClient: OmhAuthClient
 ) {
+
+    protected val logger: Logger = LoggerFactory.getLogger(javaClass)
 
     interface Builder {
 
@@ -277,7 +281,20 @@ abstract class OmhStorageClient protected constructor(
     ): String?
 
     /**
-     * This method retrieves the storage entity at specified path.
+     * This method tries resolve the storage entity at specified path.
+     *
+     * Example usage:
+     *
+     * ```
+     * val path = "/path/to/file.txt"
+     * val entity = storageClient.resolvePath(path)
+     * if (entity != null) {
+     *   Log.d("StorageClient", "Entity ${path} resolves to: ${entity.id}")
+     *   // Do something else with the entity
+     * } else {
+     *   Log.w("StorageClient", "Entity ${path} not found")
+     * }
+     * ```
      *
      * @param path The path of the storage entity
      *

--- a/packages/core/src/main/java/com/openmobilehub/android/storage/core/utils/StringExtensions.kt
+++ b/packages/core/src/main/java/com/openmobilehub/android/storage/core/utils/StringExtensions.kt
@@ -40,3 +40,15 @@ fun String.fromRFC3339StringToDate(): Date? {
         null
     }
 }
+
+fun String.splitPathToParts(): List<String> {
+    return if (!contains('/')) {
+        listOf(this)
+    } else {
+        if (endsWith("/")) {
+            substringBeforeLast("/").split("/")
+        } else {
+            split("/")
+        }.filter { it.isNotBlank() && it.isNotEmpty() }
+    }
+}

--- a/packages/core/src/test/java/com/openmobilehub/android/storage/core/utils/StringExtensionsTest.kt
+++ b/packages/core/src/test/java/com/openmobilehub/android/storage/core/utils/StringExtensionsTest.kt
@@ -89,4 +89,13 @@ class StringExtensionsTest {
         // Assert
         assertNull(result)
     }
+
+    @Test
+    fun `test splitPathToParts`() {
+        assertEquals(listOf("abc"), "abc".splitPathToParts())
+        assertEquals(listOf(""), "".splitPathToParts())
+        assertEquals(listOf(" "), " ".splitPathToParts())
+        assertEquals(listOf("a", "b", "c"), "/a/b/c".splitPathToParts())
+        assertEquals(listOf("a", "b", "c"), "/a/b/c/".splitPathToParts())
+    }
 }

--- a/packages/plugin-dropbox/build.gradle.kts
+++ b/packages/plugin-dropbox/build.gradle.kts
@@ -22,9 +22,13 @@ dependencies {
     implementation(Libs.androidxAnnotation)
     implementation(Libs.coroutinesCore)
 
+    // slf4j
+    implementation(Libs.slf4jApi)
+
     // Test dependencies
     testImplementation(kotlin("test"))
     testImplementation(Libs.junit)
     testImplementation(Libs.mockk)
     testImplementation(Libs.coroutineTesting)
+    testImplementation(Libs.slf4jAndroid)
 }

--- a/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/DropboxOmhStorageClient.kt
+++ b/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/DropboxOmhStorageClient.kt
@@ -179,6 +179,10 @@ internal class DropboxOmhStorageClient @VisibleForTesting internal constructor(
         return null
     }
 
+    override suspend fun resolvePath(path: String): OmhStorageEntity? {
+        return repository.resolvePath(path)
+    }
+
     override fun getProviderSdk(): DbxClientV2 = repository.apiService.apiClient.dropboxApiService
 
     override suspend fun getStorageUsage(): Long {

--- a/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/data/repository/DropboxFileRepository.kt
+++ b/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/data/repository/DropboxFileRepository.kt
@@ -450,4 +450,11 @@ internal class DropboxFileRepository(
     private fun isFolder(fileId: String): FolderMetadata? {
         return apiService.getFile(fileId) as? FolderMetadata
     }
+
+    fun resolvePath(path: String): OmhStorageEntity? {
+        val nodeId = apiService.queryNodeIdHaving(path)
+        return nodeId?.let {
+            metadataToOmhStorageEntity(apiService.getFile(it))
+        }
+    }
 }

--- a/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/data/service/DropboxApiService.kt
+++ b/packages/plugin-dropbox/src/main/java/com/openmobilehub/android/storage/plugin/dropbox/data/service/DropboxApiService.kt
@@ -40,7 +40,6 @@ import com.dropbox.core.v2.sharing.ShareFolderLaunch
 import com.dropbox.core.v2.sharing.SharedFileMembers
 import com.dropbox.core.v2.sharing.SharedFolderMembers
 import com.dropbox.core.v2.users.SpaceUsage
-import com.openmobilehub.android.storage.core.utils.splitPathToParts
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 
@@ -236,37 +235,7 @@ internal class DropboxApiService(internal val apiClient: DropboxApiClient) {
     }
 
     fun queryNodeIdHaving(path: String): String? {
-        val parts = path.splitPathToParts()
-
-        var currentPath = ""
-        var node: Metadata? = null
-
-        parts.forEachIndexed { index, part ->
-            val entries = listFilesAt(currentPath).entries
-            var found = false
-
-            for (entry in entries) {
-                if (entry.name == part && if (index < parts.size - 1) {
-                    entry is FolderMetadata
-                } else {
-                        true
-                    }
-                ) {
-                    currentPath += "/$part"
-                    node = entry
-                    found = true
-                    break
-                }
-            }
-
-            if (!found) {
-                return null
-            }
-        }
-
+        val node: Metadata = apiClient.dropboxApiService.files().getMetadata(path) ?: return null
         return (node as? FolderMetadata)?.id ?: (node as FileMetadata).id
     }
-
-    private fun listFilesAt(path: String): ListFolderResult =
-        apiClient.dropboxApiService.files().listFolder(path)
 }

--- a/packages/plugin-dropbox/src/test/java/com/openmobilehub/android/storage/plugin/dropbox/data/repository/DropboxFileRepositoryTest.kt
+++ b/packages/plugin-dropbox/src/test/java/com/openmobilehub/android/storage/plugin/dropbox/data/repository/DropboxFileRepositoryTest.kt
@@ -85,11 +85,6 @@ import com.openmobilehub.android.storage.plugin.dropbox.testdoubles.testOmhFolde
 import com.openmobilehub.android.storage.plugin.dropbox.testdoubles.testOmhGroupPermission
 import com.openmobilehub.android.storage.plugin.dropbox.testdoubles.testOmhUserPermission
 import com.openmobilehub.android.storage.plugin.dropbox.testdoubles.testOmhVersion
-import com.openmobilehub.android.storage.plugin.dropbox.testdoubles.testQueryFolder1
-import com.openmobilehub.android.storage.plugin.dropbox.testdoubles.testQueryFolder2
-import com.openmobilehub.android.storage.plugin.dropbox.testdoubles.testQueryFolder3
-import com.openmobilehub.android.storage.plugin.dropbox.testdoubles.testQueryFolderRsx
-import com.openmobilehub.android.storage.plugin.dropbox.testdoubles.testQueryRootFolder
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -1097,42 +1092,21 @@ class DropboxFileRepositoryTest {
 
     @Test
     fun `test resolve path of non-existent file`() {
-        every { apiService.queryNodeIdHaving(any()) } answers { callOriginal() }
+        every { apiService.queryNodeIdHaving(any()) } returns null
         assertNull(repository.resolvePath("/foo/bar"))
 
         verify {
-            apiService invoke "listFilesAt" withArguments listOf(
-                "" // Root
-            )
+            apiService.queryNodeIdHaving("/foo/bar")
         }
     }
 
     @Test
     fun `test resolve path of an existing file`() {
-        every {
-            apiService invoke "listFilesAt" withArguments
-                listOf("")
-        } returns testQueryRootFolder
-        every {
-            apiService invoke "listFilesAt" withArguments
-                listOf("/RSX")
-        } returns testQueryFolderRsx
-        every {
-            apiService invoke "listFilesAt" withArguments
-                listOf("/RSX/1")
-        } returns testQueryFolder1
-        every {
-            apiService invoke "listFilesAt" withArguments
-                listOf("/RSX/1/2")
-        } returns testQueryFolder2
-        every {
-            apiService invoke "listFilesAt" withArguments
-                listOf("/RSX/1/2/3")
-        } returns testQueryFolder3
+        every { apiService.queryNodeIdHaving("/RSX/1/2/3/testfile.jpg") } returns
+            testFileJpg().id
         every { apiService.getFile("id of file /RSX/1/2/3/testfile.jpg") } returns
             testFileJpg()
 
-        every { apiService.queryNodeIdHaving(any()) } answers { callOriginal() }
         every { metadataToOmhStorageEntity(testFileJpg()) } returns OmhStorageEntity.OmhFile(
             id = "id of file /RSX/1/2/3/testfile.jpg",
             name = "testfile.jpg",
@@ -1148,21 +1122,7 @@ class DropboxFileRepositoryTest {
         assertNotNull(result)
         assertEquals("id of file /RSX/1/2/3/testfile.jpg", result?.id)
 
-        verify {
-            apiService invoke "listFilesAt" withArguments listOf("")
-        }
-        verify {
-            apiService invoke "listFilesAt" withArguments listOf("/RSX")
-        }
-        verify {
-            apiService invoke "listFilesAt" withArguments listOf("/RSX/1")
-        }
-        verify {
-            apiService invoke "listFilesAt" withArguments listOf("/RSX/1/2")
-        }
-        verify {
-            apiService invoke "listFilesAt" withArguments listOf("/RSX/1/2/3")
-        }
+        verify { apiService.queryNodeIdHaving("/RSX/1/2/3/testfile.jpg") }
         verify { apiService.getFile("id of file /RSX/1/2/3/testfile.jpg") }
     }
 }

--- a/packages/plugin-dropbox/src/test/java/com/openmobilehub/android/storage/plugin/dropbox/testdoubles/TestOmhStorageEntity.kt
+++ b/packages/plugin-dropbox/src/test/java/com/openmobilehub/android/storage/plugin/dropbox/testdoubles/TestOmhStorageEntity.kt
@@ -23,7 +23,7 @@ import java.util.Date
 const val TEST_FILE_ID = "123"
 const val TEST_FILE_NAME = "fileName.txt"
 val TEST_FILE_CREATED_TIME = null
-val TEST_FILE_MODIFIED_TIME = TEST_FIRST_JUNE_2024_RFC_3339.fromRFC3339StringToDate()
+val TEST_FILE_MODIFIED_TIME = TEST_FIRST_JUNE_2024_RFC_3339.fromRFC3339StringToDate()!!
 const val TEST_FILE_PARENT_ID = "parentId"
 const val TEST_FILE_MIME_TYPE = "test/mime-type"
 const val TEST_FILE_EXTENSION = "txt"

--- a/packages/plugin-dropbox/src/test/java/com/openmobilehub/android/storage/plugin/dropbox/testdoubles/TestResolvePath.kt
+++ b/packages/plugin-dropbox/src/test/java/com/openmobilehub/android/storage/plugin/dropbox/testdoubles/TestResolvePath.kt
@@ -1,0 +1,60 @@
+package com.openmobilehub.android.storage.plugin.dropbox.testdoubles
+
+import com.dropbox.core.v2.files.FileMetadata
+import com.dropbox.core.v2.files.FolderMetadata
+import com.dropbox.core.v2.files.ListFolderResult
+import io.mockk.every
+import io.mockk.mockk
+
+val testQueryRootFolder = mockk<ListFolderResult>(relaxed = true).also { result ->
+    every { result.entries } returns listOf(testFolderRsx())
+}
+
+val testQueryFolderRsx = mockk<ListFolderResult>(relaxed = true).also { result ->
+    every { result.entries } returns listOf(testFolder1())
+}
+
+val testQueryFolder1 = mockk<ListFolderResult>(relaxed = true).also { result ->
+    every { result.entries } returns listOf(testFolder2())
+}
+
+val testQueryFolder2 = mockk<ListFolderResult>(relaxed = true).also { result ->
+    every { result.entries } returns listOf(testFolder3())
+}
+
+val testQueryFolder3 = mockk<ListFolderResult>(relaxed = true).also { result ->
+    every { result.entries } returns listOf(testFileJpg())
+}
+
+fun testFolderRsx(): FolderMetadata = mockk<FolderMetadata>().also { folder ->
+    every { folder.id } returns "id of folder /RSX"
+    every { folder.name } returns "RSX"
+    every { folder.parentSharedFolderId } returns ""
+}
+
+fun testFolder1(): FolderMetadata = mockk<FolderMetadata>().also { folder ->
+    every { folder.id } returns "id of folder /RSX/1"
+    every { folder.name } returns "1"
+    every { folder.parentSharedFolderId } returns "id of folder /RSX"
+}
+
+fun testFolder2(): FolderMetadata = mockk<FolderMetadata>().also { folder ->
+    every { folder.id } returns "id of folder /RSX/1/2"
+    every { folder.name } returns "2"
+    every { folder.parentSharedFolderId } returns "id of folder /RSX/1"
+}
+
+fun testFolder3(): FolderMetadata = mockk<FolderMetadata>().also { folder ->
+    every { folder.id } returns "id of folder /RSX/1/2/3"
+    every { folder.name } returns "3"
+    every { folder.parentSharedFolderId } returns "id of folder /RSX/1/2"
+}
+
+fun testFileJpg(): FileMetadata = FileMetadata(
+    "testfile.jpg",
+    "id of file /RSX/1/2/3/testfile.jpg",
+    TEST_FILE_MODIFIED_TIME,
+    TEST_FILE_MODIFIED_TIME,
+    "000000000000000000000",
+    12345L
+)

--- a/packages/plugin-googledrive-gms/build.gradle.kts
+++ b/packages/plugin-googledrive-gms/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
     // Omh Auth
     api(Libs.omhGoogleGmsAuthLibrary)
 
+    // slf4j
+    implementation(Libs.slf4jApi)
+
     // GMS
     implementation(Libs.googlePlayServicesAuth)
     implementation(Libs.googleJacksonClient)
@@ -52,4 +55,5 @@ dependencies {
     testImplementation(Libs.junit)
     testImplementation(Libs.mockk)
     testImplementation(Libs.coroutineTesting)
+    testImplementation(Libs.slf4jAndroid)
 }

--- a/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/GoogleDriveGmsOmhStorageClient.kt
+++ b/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/GoogleDriveGmsOmhStorageClient.kt
@@ -178,6 +178,10 @@ internal class GoogleDriveGmsOmhStorageClient private constructor(
         return fileRepository.getWebUrl(fileId)
     }
 
+    override suspend fun resolvePath(path: String): OmhStorageEntity? {
+        return fileRepository.resolvePath(path)
+    }
+
     override fun getProviderSdk(): Drive = fileRepository.apiService.apiProvider.googleDriveApiService
 
     override suspend fun getStorageUsage(): Long {

--- a/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/repository/GmsFileRepository.kt
+++ b/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/repository/GmsFileRepository.kt
@@ -285,4 +285,11 @@ internal class GmsFileRepository(
     } catch (exception: HttpResponseException) {
         throw ExceptionMapper.toOmhApiException(exception)
     }
+
+    fun resolvePath(path: String): OmhStorageEntity? {
+        val nodeId = apiService.queryNodeIdHaving(path)
+        return nodeId?.let {
+            apiService.getFile(it).execute().toOmhStorageEntity()
+        }
+    }
 }

--- a/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/service/GoogleDriveApiService.kt
+++ b/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/service/GoogleDriveApiService.kt
@@ -19,7 +19,10 @@ package com.openmobilehub.android.storage.plugin.googledrive.gms.data.service
 import com.google.api.client.http.FileContent
 import com.google.api.services.drive.Drive
 import com.google.api.services.drive.model.File
+import com.google.api.services.drive.model.FileList
 import com.google.api.services.drive.model.Permission
+import com.openmobilehub.android.storage.core.utils.splitPathToParts
+import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants
 
 @Suppress("TooManyFunctions")
 internal class GoogleDriveApiService(internal val apiProvider: GoogleDriveApiProvider) {
@@ -180,4 +183,25 @@ internal class GoogleDriveApiService(internal val apiProvider: GoogleDriveApiPro
                 it.setFields(queryFields)
             }
         }
+
+    fun queryNodeIdHaving(path: String): String? {
+        val parts = path.splitPathToParts()
+        var parentId = GoogleDriveGmsConstants.ROOT_FOLDER
+        for (nodeName in parts) {
+            val query = createQueryForNodeId(parentId, nodeName)
+            val files = query.files
+            if (files == null || files.isEmpty()) {
+                return null
+            } else {
+                parentId = files.first().id
+            }
+        }
+        return parentId
+    }
+
+    private fun createQueryForNodeId(parentId: String, nodeName: String): FileList =
+        apiProvider.googleDriveApiService
+            .files()
+            .list()
+            .setQ("'$parentId' in parents and name='$nodeName'").execute()
 }

--- a/packages/plugin-googledrive-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/repository/GmsFileRepositoryTest.kt
+++ b/packages/plugin-googledrive-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/repository/GmsFileRepositoryTest.kt
@@ -30,6 +30,7 @@ import com.google.api.services.drive.model.RevisionList
 import com.openmobilehub.android.storage.core.model.OmhPermissionRole
 import com.openmobilehub.android.storage.core.model.OmhStorageException
 import com.openmobilehub.android.storage.core.model.OmhStorageMetadata
+import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants
 import com.openmobilehub.android.storage.plugin.googledrive.gms.data.service.GoogleDriveApiService
 import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.TEST_EMAIL_MESSAGE
 import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.TEST_FILE_ID
@@ -43,21 +44,30 @@ import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.TEST
 import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.setUpMock
 import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.setupQuotaAvailableMock
 import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.setupQuotaUnlimitedMock
+import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.testFileJpg
 import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.testOmhCreatePermission
 import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.testOmhFile
 import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.testOmhPermission
 import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.testOmhVersion
+import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.testQueryFolder1
+import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.testQueryFolder2
+import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.testQueryFolder3
+import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.testQueryFolderRsx
+import com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles.testQueryRootFolder
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import java.io.ByteArrayInputStream
@@ -630,5 +640,77 @@ internal class GmsFileRepositoryTest {
 
         fileRepositoryImpl.getStorageQuota()
         fileRepositoryImpl.getStorageUsage()
+    }
+
+    @Test
+    fun `test resolve path of non-existent file`() {
+        every { apiService.queryNodeIdHaving(any()) } answers { callOriginal() }
+        assertNull(fileRepositoryImpl.resolvePath("/foo/bar"))
+
+        verify {
+            apiService invoke "createQueryForNodeId" withArguments listOf(
+                GoogleDriveGmsConstants.ROOT_FOLDER,
+                "foo"
+            )
+        }
+    }
+
+    @Test
+    fun `test resolve path of an existing file`() {
+        every {
+            apiService invoke "createQueryForNodeId" withArguments
+                listOf(GoogleDriveGmsConstants.ROOT_FOLDER, "RSX")
+        } returns testQueryRootFolder
+        every {
+            apiService invoke "createQueryForNodeId" withArguments
+                listOf("id of folder /RSX", "1")
+        } returns testQueryFolderRsx
+        every {
+            apiService invoke "createQueryForNodeId" withArguments
+                listOf("id of folder /RSX/1", "2")
+        } returns testQueryFolder1
+        every {
+            apiService invoke "createQueryForNodeId" withArguments
+                listOf("id of folder /RSX/1/2", "3")
+        } returns testQueryFolder2
+        every {
+            apiService invoke "createQueryForNodeId" withArguments
+                listOf("id of folder /RSX/1/2/3", "testfile.jpg")
+        } returns testQueryFolder3
+        every { apiService.getFile("id of file /RSX/1/2/3/testfile.jpg") } returns
+            mockk<Drive.Files.Get>(relaxed = true).also {
+                every { it.execute() } returns testFileJpg()
+            }
+        every { apiService.queryNodeIdHaving(any()) } answers { callOriginal() }
+
+        val result = fileRepositoryImpl.resolvePath("/RSX/1/2/3/testfile.jpg")
+        assertNotNull(result)
+        assertEquals("id of file /RSX/1/2/3/testfile.jpg", result?.id)
+
+        verify {
+            apiService invoke "createQueryForNodeId" withArguments listOf(
+                GoogleDriveGmsConstants.ROOT_FOLDER,
+                "RSX"
+            )
+        }
+        verify {
+            apiService invoke "createQueryForNodeId" withArguments listOf(
+                "id of folder /RSX",
+                "1"
+            )
+        }
+        verify {
+            apiService invoke "createQueryForNodeId" withArguments
+                listOf("id of folder /RSX/1", "2")
+        }
+        verify {
+            apiService invoke "createQueryForNodeId" withArguments
+                listOf("id of folder /RSX/1/2", "3")
+        }
+        verify {
+            apiService invoke "createQueryForNodeId" withArguments
+                listOf("id of folder /RSX/1/2/3", "testfile.jpg")
+        }
+        verify { apiService.getFile("id of file /RSX/1/2/3/testfile.jpg") }
     }
 }

--- a/packages/plugin-googledrive-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/gms/testdoubles/TestResolvePath.kt
+++ b/packages/plugin-googledrive-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/gms/testdoubles/TestResolvePath.kt
@@ -1,0 +1,78 @@
+package com.openmobilehub.android.storage.plugin.googledrive.gms.testdoubles
+
+import com.google.api.client.util.DateTime
+import com.google.api.services.drive.model.File
+import com.google.api.services.drive.model.FileList
+import com.openmobilehub.android.storage.plugin.googledrive.gms.GoogleDriveGmsConstants
+import io.mockk.every
+import io.mockk.mockk
+
+val testQueryRootFolder = mockk<FileList>(relaxed = true).also { result ->
+    every { result.files } returns listOf(testFolderRsx())
+}
+
+val testQueryFolderRsx = mockk<FileList>(relaxed = true).also { result ->
+    every { result.files } returns listOf(testFolder1())
+}
+
+val testQueryFolder1 = mockk<FileList>(relaxed = true).also { result ->
+    every { result.files } returns listOf(testFolder2())
+}
+
+val testQueryFolder2 = mockk<FileList>(relaxed = true).also { result ->
+    every { result.files } returns listOf(testFolder3())
+}
+
+val testQueryFolder3 = mockk<FileList>(relaxed = true).also { result ->
+    every { result.files } returns listOf(testFileJpg())
+}
+
+fun testFolderRsx(): File = mockk<File>().also { file ->
+    every { file.id } returns "id of folder /RSX"
+    every { file.name } returns "RSX"
+    every { file.createdTime } returns DateTime(TEST_FILE_CREATED_TIME)
+    every { file.modifiedTime } returns DateTime(TEST_FILE_MODIFIED_TIME)
+    every { file.parents } returns listOf(GoogleDriveGmsConstants.ROOT_FOLDER)
+    every { file.mimeType } returns GoogleDriveGmsConstants.FOLDER_MIME_TYPE
+    every { file.size } returns 0
+}
+
+fun testFolder1(): File = mockk<File>().also { file ->
+    every { file.id } returns "id of folder /RSX/1"
+    every { file.name } returns "1"
+    every { file.createdTime } returns DateTime(TEST_FILE_CREATED_TIME)
+    every { file.modifiedTime } returns DateTime(TEST_FILE_MODIFIED_TIME)
+    every { file.parents } returns listOf("id of folder /RSX")
+    every { file.mimeType } returns GoogleDriveGmsConstants.FOLDER_MIME_TYPE
+    every { file.size } returns 0
+}
+
+fun testFolder2(): File = mockk<File>().also { file ->
+    every { file.id } returns "id of folder /RSX/1/2"
+    every { file.name } returns "2"
+    every { file.createdTime } returns DateTime(TEST_FILE_CREATED_TIME)
+    every { file.modifiedTime } returns DateTime(TEST_FILE_MODIFIED_TIME)
+    every { file.parents } returns listOf("id of folder /RSX/1")
+    every { file.mimeType } returns GoogleDriveGmsConstants.FOLDER_MIME_TYPE
+    every { file.size } returns 0
+}
+
+fun testFolder3(): File = mockk<File>().also { file ->
+    every { file.id } returns "id of folder /RSX/1/2/3"
+    every { file.name } returns "3"
+    every { file.createdTime } returns DateTime(TEST_FILE_CREATED_TIME)
+    every { file.modifiedTime } returns DateTime(TEST_FILE_MODIFIED_TIME)
+    every { file.parents } returns listOf("id of folder /RSX/1/2")
+    every { file.mimeType } returns GoogleDriveGmsConstants.FOLDER_MIME_TYPE
+    every { file.size } returns 0
+}
+
+fun testFileJpg(): File = mockk<File>(relaxed = true).also { file ->
+    every { file.id } returns "id of file /RSX/1/2/3/testfile.jpg"
+    every { file.name } returns "testfile.jpg"
+    every { file.createdTime } returns DateTime(TEST_FILE_CREATED_TIME)
+    every { file.modifiedTime } returns DateTime(TEST_FILE_MODIFIED_TIME)
+    every { file.parents } returns listOf("id of folder /RSX/1/2/3")
+    every { file.mimeType } returns "image/jpeg"
+    every { file.size } returns 12345
+}

--- a/packages/plugin-googledrive-non-gms/build.gradle.kts
+++ b/packages/plugin-googledrive-non-gms/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
     // Omh Auth
     api(Libs.omhGoogleNonGmsAuthLibrary)
 
+    // slf4j
+    implementation(Libs.slf4jApi)
+
     // Retrofit setup
     implementation(Libs.retrofit)
     implementation(Libs.retrofitJacksonConverter)
@@ -42,4 +45,5 @@ dependencies {
     testImplementation(Libs.mockk)
     testImplementation(Libs.coroutineTesting)
     testImplementation(Libs.json)
+    testImplementation(Libs.slf4jAndroid)
 }

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/GoogleDriveNonGmsOmhStorageClient.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/GoogleDriveNonGmsOmhStorageClient.kt
@@ -160,6 +160,10 @@ internal class GoogleDriveNonGmsOmhStorageClient private constructor(
         return fileRepository.getFileMetadata(fileId)
     }
 
+    override suspend fun resolvePath(path: String): OmhStorageEntity? {
+        return fileRepository.resolvePath(path)
+    }
+
     override fun getProviderSdk(): Any = throw throw UnsupportedOperationException(
         "Google Drive non-gms implementation uses REST API underneath."
     )

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/GoogleDriveNonGmsOmhStorageClient.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/GoogleDriveNonGmsOmhStorageClient.kt
@@ -24,6 +24,7 @@ import com.openmobilehub.android.storage.core.model.OmhFileVersion
 import com.openmobilehub.android.storage.core.model.OmhPermission
 import com.openmobilehub.android.storage.core.model.OmhPermissionRole
 import com.openmobilehub.android.storage.core.model.OmhStorageEntity
+import com.openmobilehub.android.storage.core.model.OmhStorageException
 import com.openmobilehub.android.storage.core.model.OmhStorageMetadata
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.mapper.LocalFileToMimeType
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.repository.NonGmsFileRepository
@@ -161,7 +162,24 @@ internal class GoogleDriveNonGmsOmhStorageClient private constructor(
     }
 
     override suspend fun resolvePath(path: String): OmhStorageEntity? {
-        return fileRepository.resolvePath(path)
+        val startTime = System.currentTimeMillis()
+        try {
+            val retval = fileRepository.resolvePath(path)
+            if (logger.isDebugEnabled && retval != null) {
+                logger.debug("resolvePath: \"$path\" -> $retval")
+            } else {
+                logger.debug("resolvePath: \"$path\" not found")
+            }
+            return retval
+        } catch (e: OmhStorageException.ApiException) {
+            logger.error("resolvePath failed: $path", e)
+            throw e
+        } finally {
+            val endTime = System.currentTimeMillis()
+            if (logger.isDebugEnabled) {
+                logger.debug("resolvePath took ${endTime - startTime} ms")
+            }
+        }
     }
 
     override fun getProviderSdk(): Any = throw throw UnsupportedOperationException(

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
@@ -24,6 +24,7 @@ import com.openmobilehub.android.storage.core.model.OmhPermissionRole
 import com.openmobilehub.android.storage.core.model.OmhStorageEntity
 import com.openmobilehub.android.storage.core.model.OmhStorageException
 import com.openmobilehub.android.storage.core.model.OmhStorageMetadata
+import com.openmobilehub.android.storage.core.utils.splitPathToParts
 import com.openmobilehub.android.storage.core.utils.toInputStream
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.mapper.LocalFileToMimeType
@@ -528,5 +529,22 @@ internal class NonGmsFileRepository(
         } else {
             throw response.toApiException()
         }
+    }
+
+    suspend fun resolvePath(path: String): OmhStorageEntity? {
+        val parts = path.splitPathToParts()
+        var parentId = GoogleDriveNonGmsConstants.ROOT_FOLDER
+        for (nodeName in parts) {
+            val entries = getFiles("'$parentId' in parents and name='$nodeName'")
+            if (entries.isEmpty()) {
+                return null
+            } else {
+                parentId = entries.first().id
+            }
+        }
+
+        return retrofitImpl
+            .getGoogleStorageApiService()
+            .getFile(parentId).body()?.toOmhStorageEntity()
     }
 }

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/service/GoogleStorageApiService.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/service/GoogleStorageApiService.kt
@@ -81,6 +81,11 @@ internal interface GoogleStorageApiService {
         private const val PERMISSION_ID = "permissionId"
     }
 
+    @GET("$FILES_PARTICLE/{$FILE_ID}")
+    suspend fun getFile(
+        @Path(FILE_ID) fileId: String
+    ): Response<FileRemoteResponse>
+
     @GET(FILES_PARTICLE)
     suspend fun getFilesList(
         @Query(QUERY_Q) query: String,

--- a/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepositoryTest.kt
+++ b/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepositoryTest.kt
@@ -26,6 +26,7 @@ import com.openmobilehub.android.storage.core.utils.toInputStream
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.mapper.LocalFileToMimeType
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.repository.NonGmsFileRepository.Companion.STORAGE_QUOTA
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.GoogleStorageApiService
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.FileListRemoteResponse
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.FileRemoteResponse
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.retrofit.GoogleStorageApiServiceProvider
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.utils.toByteArrayOutputStream
@@ -45,6 +46,7 @@ import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.c
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.createOwnerPermission
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.createOwnerPermissionRequestBody
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.ownerUpdatePermission
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testFileJpg
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testFileListRemote
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testFileRemote
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testOmhFile
@@ -52,6 +54,11 @@ import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.t
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testOmhVersion
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testPermissionResponse
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testPermissionsListResponse
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testQueryFolder1
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testQueryFolder2
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testQueryFolder3
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testQueryFolderRsx
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testQueryRootFolder
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testVersionListRemote
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles.testWebUrlResponse
 import io.mockk.MockKAnnotations
@@ -68,6 +75,8 @@ import okhttp3.Headers
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.ResponseBody
 import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import retrofit2.Response
@@ -1086,5 +1095,45 @@ internal class NonGmsFileRepositoryTest {
             fileRepositoryImpl.getStorageUsage()
 
             coVerify { googleStorageApiService.about(fields = STORAGE_QUOTA) }
+        }
+
+    @Test
+    fun `test resolve path of non-existent file`() =
+        runTest {
+            coEvery { googleStorageApiService.getFilesList(any(), any()) } returns Response.success(
+                FileListRemoteResponse(emptyList())
+            )
+            assertNull(fileRepositoryImpl.resolvePath("/foo/bar"))
+
+            coVerify {
+                googleStorageApiService.getFilesList("'root' in parents and name='foo'")
+            }
+        }
+
+    @Test
+    fun `test resolve path of an existing file`() =
+        runTest {
+            coEvery {
+                googleStorageApiService.getFilesList("'root' in parents and name='RSX'")
+            } returns testQueryRootFolder
+            coEvery {
+                googleStorageApiService.getFilesList("'id of folder /RSX' in parents and name='1'")
+            } returns testQueryFolderRsx
+            coEvery {
+                googleStorageApiService.getFilesList("'id of folder /RSX/1' in parents and name='2'")
+            } returns testQueryFolder1
+            coEvery {
+                googleStorageApiService.getFilesList("'id of folder /RSX/1/2' in parents and name='3'")
+            } returns testQueryFolder2
+            coEvery {
+                googleStorageApiService.getFilesList("'id of folder /RSX/1/2/3' in parents and name='testfile.jpg'")
+            } returns testQueryFolder3
+            coEvery {
+                googleStorageApiService.getFile("id of file /RSX/1/2/3/testfile.jpg")
+            } returns Response.success(testFileJpg)
+
+            val result = fileRepositoryImpl.resolvePath("/RSX/1/2/3/testfile.jpg")
+            assertNotNull(result)
+            assertEquals("id of file /RSX/1/2/3/testfile.jpg", result?.id)
         }
 }

--- a/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/testdoubles/TestResolvePath.kt
+++ b/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/testdoubles/TestResolvePath.kt
@@ -1,0 +1,81 @@
+package com.openmobilehub.android.storage.plugin.googledrive.nongms.testdoubles
+
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.GoogleDriveNonGmsConstants
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.FileListRemoteResponse
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.FileRemoteResponse
+import retrofit2.Response
+
+internal val testFolderRsx = FileRemoteResponse(
+    "id of folder /RSX",
+    "RSX",
+    TEST_FIRST_MAY_2024_RFC_3339,
+    TEST_FIRST_JUNE_2024_RFC_3339,
+    listOf(GoogleDriveNonGmsConstants.ROOT_FOLDER),
+    GoogleDriveNonGmsConstants.FOLDER_MIME_TYPE,
+    "",
+    0
+)
+
+internal val testFolder1 = FileRemoteResponse(
+    "id of folder /RSX/1",
+    "1",
+    TEST_FIRST_MAY_2024_RFC_3339,
+    TEST_FIRST_JUNE_2024_RFC_3339,
+    listOf("id of folder /RSX"),
+    GoogleDriveNonGmsConstants.FOLDER_MIME_TYPE,
+    "",
+    0
+)
+
+internal val testFolder2 = FileRemoteResponse(
+    "id of folder /RSX/1/2",
+    "2",
+    TEST_FIRST_MAY_2024_RFC_3339,
+    TEST_FIRST_JUNE_2024_RFC_3339,
+    listOf("id of folder /RSX/1"),
+    GoogleDriveNonGmsConstants.FOLDER_MIME_TYPE,
+    "",
+    0
+)
+
+internal val testFolder3 = FileRemoteResponse(
+    "id of folder /RSX/1/2/3",
+    "3",
+    TEST_FIRST_MAY_2024_RFC_3339,
+    TEST_FIRST_JUNE_2024_RFC_3339,
+    listOf("id of folder /RSX/1/2"),
+    GoogleDriveNonGmsConstants.FOLDER_MIME_TYPE,
+    "",
+    0
+)
+
+internal val testFileJpg = FileRemoteResponse(
+    "id of file /RSX/1/2/3/testfile.jpg",
+    "testfile.jpg",
+    TEST_FIRST_MAY_2024_RFC_3339,
+    TEST_FIRST_JUNE_2024_RFC_3339,
+    listOf("id of folder /RSX/1/2/3"),
+    "image/jpeg",
+    "jpg",
+    12345
+)
+
+internal val testQueryRootFolder = Response.success(
+    FileListRemoteResponse(listOf(testFolderRsx))
+)
+
+internal val testQueryFolderRsx = Response.success(
+    FileListRemoteResponse(listOf(testFolder1))
+)
+
+internal val testQueryFolder1 = Response.success(
+    FileListRemoteResponse(listOf(testFolder2))
+)
+
+internal val testQueryFolder2 = Response.success(
+    FileListRemoteResponse(listOf(testFolder3))
+)
+
+internal val testQueryFolder3 = Response.success(
+    FileListRemoteResponse(listOf(testFileJpg))
+)

--- a/packages/plugin-onedrive/build.gradle.kts
+++ b/packages/plugin-onedrive/build.gradle.kts
@@ -26,6 +26,9 @@ dependencies {
     // MsGraph
     api(Libs.msGraph)
 
+    // slf4j
+    implementation(Libs.slf4jApi)
+
     // Retrofit setup
     implementation(Libs.retrofit)
     implementation(Libs.retrofitJacksonConverter)
@@ -40,4 +43,5 @@ dependencies {
     testImplementation(Libs.junit)
     testImplementation(Libs.mockk)
     testImplementation(Libs.coroutineTesting)
+    testImplementation(Libs.slf4jAndroid)
 }

--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/OneDriveOmhStorageClient.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/OneDriveOmhStorageClient.kt
@@ -175,6 +175,10 @@ internal class OneDriveOmhStorageClient @VisibleForTesting internal constructor(
         return repository.getWebUrl(fileId)
     }
 
+    override suspend fun resolvePath(path: String): OmhStorageEntity? {
+        return repository.resolvePath(path)
+    }
+
     override fun getProviderSdk(): GraphServiceClient =
         repository.apiService.apiClient.graphServiceClient
 

--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/repository/OneDriveFileRepository.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/repository/OneDriveFileRepository.kt
@@ -267,4 +267,12 @@ internal class OneDriveFileRepository(
     } catch (exception: ApiException) {
         throw ExceptionMapper.toOmhApiException(exception)
     }
+
+    fun resolvePath(path: String): OmhStorageEntity? = kotlin.runCatching {
+        apiService.resolvePath(path)?.let {
+            driveItemToOmhStorageEntity(it)
+        }
+    }.onFailure { exception: Throwable ->
+        throw ExceptionMapper.toOmhApiException(exception as ApiException)
+    }.getOrNull()
 }

--- a/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveApiService.kt
+++ b/packages/plugin-onedrive/src/main/java/com/openmobilehub/android/storage/plugin/onedrive/data/service/OneDriveApiService.kt
@@ -198,6 +198,13 @@ internal class OneDriveApiService(internal val apiClient: OneDriveApiClient) {
         return apiClient.graphServiceClient.drives().byDriveId(driveId).get()
     }
 
+    fun resolvePath(path: String): DriveItem? {
+        return apiClient.graphServiceClient.drives()
+            .byDriveId(driveId)
+            .items()
+            .byDriveItemId("root:$path").get()
+    }
+
     @VisibleForTesting
     internal class DriveIdCache(private val apiClient: OneDriveApiClient) {
         private var cachedDriveId: String? = null


### PR DESCRIPTION
## Summary

Adds `resolvePath()` function, to conveniently resolve a folder/file's node ID on cloud storage using their virtual path on the cloud storage.

Also updated FileViewer sample app to showcase use of folder size and storage quota information previously submitted in #97 and #98.

## Demo
N/A (`resolvePath()` usually won't use directly in UI interaction) 

## Checklist:
- [x] Documentation is up to date to reflect these changes
- [x] Created Unit tests