### PR TITLE
Bugfix: Google Drive API about() set storageQuota field

### DIFF
--- a/packages/core/src/test/java/com/openmobilehub/android/storage/core/utils/OmhStorageClientExtensionsTest.kt
+++ b/packages/core/src/test/java/com/openmobilehub/android/storage/core/utils/OmhStorageClientExtensionsTest.kt
@@ -12,12 +12,14 @@ import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class OmhStorageClientExtensionsTest {
 
     @MockK(relaxed = true)

--- a/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/repository/GmsFileRepository.kt
+++ b/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/repository/GmsFileRepository.kt
@@ -45,6 +45,7 @@ internal class GmsFileRepository(
 ) {
     companion object {
         private const val ANY_MIME_TYPE = "*/*"
+        private const val QUERY_REQUEST_STORAGE_QUOTA = "storageQuota"
     }
 
     internal interface Builder {
@@ -273,13 +274,13 @@ internal class GmsFileRepository(
     }
 
     fun getStorageUsage(): Long = try {
-        apiService.about().execute().storageQuota.usageInDrive
+        apiService.about(QUERY_REQUEST_STORAGE_QUOTA).execute().storageQuota.usageInDrive
     } catch (exception: HttpResponseException) {
         throw ExceptionMapper.toOmhApiException(exception)
     }
 
     fun getStorageQuota(): Long = try {
-        val retval: Long? = apiService.about().execute().storageQuota.limit
+        val retval: Long? = apiService.about(QUERY_REQUEST_STORAGE_QUOTA).execute().storageQuota.limit
         retval ?: -1L
     } catch (exception: HttpResponseException) {
         throw ExceptionMapper.toOmhApiException(exception)

--- a/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/service/GoogleDriveApiService.kt
+++ b/packages/plugin-googledrive-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/service/GoogleDriveApiService.kt
@@ -174,5 +174,10 @@ internal class GoogleDriveApiService(internal val apiProvider: GoogleDriveApiPro
             fields = WEB_URL_FIELD
         }
 
-    fun about(): Drive.About.Get = apiProvider.googleDriveApiService.about().get()
+    fun about(queryFields: String? = null): Drive.About.Get =
+        apiProvider.googleDriveApiService.about().get().also {
+            if (!queryFields.isNullOrEmpty()) {
+                it.setFields(queryFields)
+            }
+        }
 }

--- a/packages/plugin-googledrive-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/repository/GmsFileRepositoryTest.kt
+++ b/packages/plugin-googledrive-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/gms/data/repository/GmsFileRepositoryTest.kt
@@ -605,24 +605,28 @@ internal class GmsFileRepositoryTest {
     fun `test getStorageQuota() and getStorageUsage() requests`() {
         about.setupQuotaAvailableMock()
         every { aboutRequest.execute() } returns about
-        every { apiService.about() } returns aboutRequest
+        every { apiService.about(queryFields = "storageQuota") } returns aboutRequest
 
         assertEquals(100L, fileRepositoryImpl.getStorageUsage())
         assertEquals(104857600L, fileRepositoryImpl.getStorageQuota())
+
+        verify { apiService.about(queryFields = "storageQuota") }
     }
 
     @Test
     fun `test getStorageQuota() requests with unlimited quota`() {
         about.setupQuotaUnlimitedMock()
         every { aboutRequest.execute() } returns about
-        every { apiService.about() } returns aboutRequest
+        every { apiService.about(queryFields = "storageQuota") } returns aboutRequest
 
         assertEquals(-1L, fileRepositoryImpl.getStorageQuota())
+
+        verify { apiService.about(queryFields = "storageQuota") }
     }
 
     @Test(expected = OmhStorageException.ApiException::class)
     fun `scenario when about request fails, ApiException is thrown`() {
-        every { apiService.about() }.throws(responseException)
+        every { apiService.about(any()) }.throws(responseException)
 
         fileRepositoryImpl.getStorageQuota()
         fileRepositoryImpl.getStorageUsage()

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
@@ -57,11 +57,13 @@ internal class NonGmsFileRepository(
 ) {
 
     companion object {
+        @VisibleForTesting
+        const val STORAGE_QUOTA = "storageQuota"
+
         private const val FILE_NAME_KEY = "name"
         private const val MIME_TYPE_KEY = "mimeType"
         private const val FILE_PARENTS_KEY = "parents"
         private const val FILE_TRASHED_KEY = "trashed"
-        private const val STORAGE_QUOTA = "storageQuota"
         private const val MEDIA = "media"
 
         private const val LOCATION_HEADER = "Location"

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepository.kt
@@ -61,6 +61,7 @@ internal class NonGmsFileRepository(
         private const val MIME_TYPE_KEY = "mimeType"
         private const val FILE_PARENTS_KEY = "parents"
         private const val FILE_TRASHED_KEY = "trashed"
+        private const val STORAGE_QUOTA = "storageQuota"
         private const val MEDIA = "media"
 
         private const val LOCATION_HEADER = "Location"
@@ -508,7 +509,7 @@ internal class NonGmsFileRepository(
     }
 
     suspend fun getStorageUsage(): Long {
-        val response = retrofitImpl.getGoogleStorageApiService().about()
+        val response = retrofitImpl.getGoogleStorageApiService().about(fields = STORAGE_QUOTA)
 
         return if (response.isSuccessful) {
             response.body()!!.storageQuota.usageInDrive
@@ -518,7 +519,7 @@ internal class NonGmsFileRepository(
     }
 
     suspend fun getStorageQuota(): Long {
-        val response = retrofitImpl.getGoogleStorageApiService().about()
+        val response = retrofitImpl.getGoogleStorageApiService().about(fields = STORAGE_QUOTA)
 
         return if (response.isSuccessful) {
             response.body()!!.storageQuota.limit

--- a/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/service/GoogleStorageApiService.kt
+++ b/packages/plugin-googledrive-non-gms/src/main/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/service/GoogleStorageApiService.kt
@@ -217,5 +217,7 @@ internal interface GoogleStorageApiService {
     ): Response<FileRemoteResponse>
 
     @GET(ABOUT)
-    suspend fun about(): Response<AboutResponse>
+    suspend fun about(
+        @Query(QUERY_FIELDS) fields: String? = null
+    ): Response<AboutResponse>
 }

--- a/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepositoryTest.kt
+++ b/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepositoryTest.kt
@@ -24,6 +24,7 @@ import com.openmobilehub.android.storage.core.model.OmhStorageException
 import com.openmobilehub.android.storage.core.model.OmhStorageMetadata
 import com.openmobilehub.android.storage.core.utils.toInputStream
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.mapper.LocalFileToMimeType
+import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.repository.NonGmsFileRepository.Companion.STORAGE_QUOTA
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.GoogleStorageApiService
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.response.FileRemoteResponse
 import com.openmobilehub.android.storage.plugin.googledrive.nongms.data.service.retrofit.GoogleStorageApiServiceProvider
@@ -1044,7 +1045,7 @@ internal class NonGmsFileRepositoryTest {
     fun `test getStorageQuota() and getStorageUsage() requests`() =
         runTest {
             coEvery {
-                googleStorageApiService.about("storageQuota")
+                googleStorageApiService.about(STORAGE_QUOTA)
             } returns Response.success(
                 200,
                 aboutResponseWithQuotaImposed
@@ -1053,14 +1054,14 @@ internal class NonGmsFileRepositoryTest {
             assertEquals(100L, fileRepositoryImpl.getStorageUsage())
             assertEquals(104857600L, fileRepositoryImpl.getStorageQuota())
 
-            coVerify { googleStorageApiService.about(fields = "storageQuota") }
+            coVerify { googleStorageApiService.about(fields = STORAGE_QUOTA) }
         }
 
     @Test
     fun `test getStorageQuota() requests with unlimited quota`() =
         runTest {
             coEvery {
-                googleStorageApiService.about("storageQuota")
+                googleStorageApiService.about(STORAGE_QUOTA)
             } returns Response.success(
                 200,
                 aboutResponseWithUnlimitedQuota
@@ -1068,7 +1069,7 @@ internal class NonGmsFileRepositoryTest {
 
             assertEquals(-1L, fileRepositoryImpl.getStorageQuota())
 
-            coVerify { googleStorageApiService.about(fields = "storageQuota") }
+            coVerify { googleStorageApiService.about(fields = STORAGE_QUOTA) }
         }
 
     @Test(expected = OmhStorageException.ApiException::class)
@@ -1084,6 +1085,6 @@ internal class NonGmsFileRepositoryTest {
             fileRepositoryImpl.getStorageQuota()
             fileRepositoryImpl.getStorageUsage()
 
-            coVerify { googleStorageApiService.about(fields = "storageQuota") }
+            coVerify { googleStorageApiService.about(fields = STORAGE_QUOTA) }
         }
 }

--- a/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepositoryTest.kt
+++ b/packages/plugin-googledrive-non-gms/src/test/java/com/openmobilehub/android/storage/plugin/googledrive/nongms/data/repository/NonGmsFileRepositoryTest.kt
@@ -1044,7 +1044,7 @@ internal class NonGmsFileRepositoryTest {
     fun `test getStorageQuota() and getStorageUsage() requests`() =
         runTest {
             coEvery {
-                googleStorageApiService.about()
+                googleStorageApiService.about("storageQuota")
             } returns Response.success(
                 200,
                 aboutResponseWithQuotaImposed
@@ -1052,26 +1052,30 @@ internal class NonGmsFileRepositoryTest {
 
             assertEquals(100L, fileRepositoryImpl.getStorageUsage())
             assertEquals(104857600L, fileRepositoryImpl.getStorageQuota())
+
+            coVerify { googleStorageApiService.about(fields = "storageQuota") }
         }
 
     @Test
     fun `test getStorageQuota() requests with unlimited quota`() =
         runTest {
             coEvery {
-                googleStorageApiService.about()
+                googleStorageApiService.about("storageQuota")
             } returns Response.success(
                 200,
                 aboutResponseWithUnlimitedQuota
             )
 
             assertEquals(-1L, fileRepositoryImpl.getStorageQuota())
+
+            coVerify { googleStorageApiService.about(fields = "storageQuota") }
         }
 
     @Test(expected = OmhStorageException.ApiException::class)
     fun `scenario when about request fails, ApiException is thrown`() =
         runTest {
             coEvery {
-                googleStorageApiService.about()
+                googleStorageApiService.about(any())
             } returns Response.error(
                 500,
                 responseBody
@@ -1079,5 +1083,7 @@ internal class NonGmsFileRepositoryTest {
 
             fileRepositoryImpl.getStorageQuota()
             fileRepositoryImpl.getStorageUsage()
+
+            coVerify { googleStorageApiService.about(fields = "storageQuota") }
         }
 }


### PR DESCRIPTION
## Summary

As documented in https://developers.google.com/drive/api/reference/rest/v3/about/get, the fields parameter is required, hence setting fields = storageQuota for quota query to succeed.

## Demo
Changes is internal, hence should not affect display to end user at sample app.

## Checklist:
- [x] Documentation is up to date to reflect these changes - changes is internal, hence should not need updating
- [x] Created Unit tests